### PR TITLE
Implement mapper for base java types

### DIFF
--- a/sadu-core/src/main/java/de/chojo/sadu/exceptions/ThrowingBiFunction.java
+++ b/sadu-core/src/main/java/de/chojo/sadu/exceptions/ThrowingBiFunction.java
@@ -1,0 +1,27 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2022 RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.exceptions;
+
+/**
+ * Represents a function which can throw an exception.
+ * <p>
+ * this is usefull when you need to delegate checked exceptions
+ *
+ * @param <R> type of result
+ * @param <T> type of input
+ * @param <E> type of exception
+ */
+public interface ThrowingBiFunction<T, U, R, E extends Exception> {
+    /**
+     * A function which maps a value to another value and can throw an exception
+     *
+     * @param t input
+     * @return value
+     * @throws E if something went wrong
+     */
+    R apply(T t, U u) throws E;
+}

--- a/sadu-core/src/main/java/de/chojo/sadu/jdbc/RemoteJdbcConfig.java
+++ b/sadu-core/src/main/java/de/chojo/sadu/jdbc/RemoteJdbcConfig.java
@@ -17,7 +17,7 @@ public abstract class RemoteJdbcConfig<T extends RemoteJdbcConfig<?>> extends Jd
     private static final Pattern IPV4 = Pattern.compile("^(?:\\d{1,3}\\.){3}\\d{1,3}$");
     private static final Pattern IPV6 = Pattern.compile(
             "(([\\da-fA-F]{1,4}:){7}[\\da-fA-F]{1,4}|([\\da-fA-F]{1,4}:){1,7}:|([\\da-fA-F]{1,4}:){1,6}:[\\da-fA-F]{1,4}|([\\da-fA-F]{1,4}:){1,5}(:[\\da-fA-F]{1,4}){1,2}|([\\da-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([\\da-fA-F]{1,4}:){1,3}(:[\\da-fA-F]{1,4}){1,4}|([\\da-fA-F]{1,4}:){1,2}(:[\\da-fA-F]{1,4}){1,5}|[\\da-fA-F]{1,4}:((:[\\da-fA-F]{1,4}){1,6})|:((:[\\da-fA-F]{1,4}){1,7}|:)|fe80:(:[\\da-fA-F]{0,4}){0,4}%[\\da-zA-Z]+|::(ffff(:0{1,4})?:)?((25[0-5]|(2[0-4]|1?\\d)?\\d)\\.){3}(25[0-5]|(2[0-4]|1?\\d)?\\d)|([\\da-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1?\\d)?\\d)\\.){3}(25[0-5]|(2[0-4]|1?\\d)?\\d))");
-    private String host;
+    private String host = "localhost";
     private String port;
     private String database;
 

--- a/sadu-core/src/main/java/de/chojo/sadu/types/SqlType.java
+++ b/sadu-core/src/main/java/de/chojo/sadu/types/SqlType.java
@@ -9,7 +9,6 @@ package de.chojo.sadu.types;
 /**
  * Represents a named data type in a database.
  */
-@FunctionalInterface
 public interface SqlType {
     /**
      * Creates a new sql type with a name
@@ -17,8 +16,18 @@ public interface SqlType {
      * @param name name
      * @return new type
      */
-    static SqlType ofName(String name) {
-        return () -> name;
+    static SqlType ofName(String name, String... alias) {
+        return new SqlType() {
+            @Override
+            public String name() {
+                return name;
+            }
+
+            @Override
+            public String[] alias() {
+                return alias;
+            }
+        };
     }
 
     /**
@@ -27,4 +36,21 @@ public interface SqlType {
      * @return type
      */
     String name();
+
+    /**
+     * Alias for a type.
+     * <p>
+     * E.g. INTEGER for INT
+     *
+     * @return array of aliase for this type
+     */
+    String[] alias();
+
+    default String descr() {
+        if (alias().length == 0) {
+            return name();
+        }
+        return "%s (%s)".formatted(name(), String.join(", ", alias()));
+    }
+
 }

--- a/sadu-core/src/test/java/de/chojo/sadu/jdbc/RemoteJdbcConfigTest.java
+++ b/sadu-core/src/test/java/de/chojo/sadu/jdbc/RemoteJdbcConfigTest.java
@@ -32,13 +32,13 @@ class RemoteJdbcConfigTest {
     @Test
     void testDatabase() {
         var jdbcUrl = jdbc.database("database").jdbcUrl();
-        Assertions.assertEquals("jdbc:driver:database", jdbcUrl);
+        Assertions.assertEquals("jdbc:driver://localhost/database", jdbcUrl);
     }
 
     @Test
     void testNone() {
         var jdbcUrl = jdbc.jdbcUrl();
-        Assertions.assertEquals("jdbc:driver:/", jdbcUrl);
+        Assertions.assertEquals("jdbc:driver://localhost/", jdbcUrl);
     }
 
     @Test
@@ -56,7 +56,6 @@ class RemoteJdbcConfigTest {
     @Test
     void testPort() {
         jdbc.port(1234);
-        Assertions.assertThrows(IllegalStateException.class, () -> jdbc.jdbcUrl());
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> jdbc.port(0));
         Assertions.assertThrows(IllegalArgumentException.class, () -> jdbc.port("0"));

--- a/sadu-mapper/build.gradle.kts
+++ b/sadu-mapper/build.gradle.kts
@@ -1,5 +1,4 @@
 
 dependencies {
     api(project(":sadu-core"))
-    api(project(":sadu-mapper"))
 }

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/DefaultMapper.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/DefaultMapper.java
@@ -14,17 +14,14 @@ import de.chojo.sadu.wrapper.util.Row;
 
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 public final class DefaultMapper {
     private DefaultMapper() {
@@ -63,11 +60,11 @@ public final class DefaultMapper {
         return RowMapper.forClass(java.util.UUID.class)
                         .mapper(row -> {
                             ResultSetMetaData meta = row.getMetaData();
-                            Optional<Integer> columnIndexOfType = Results.getColumnIndexOfType(meta, textTypes);
+                            Optional<Integer> columnIndexOfType = Results.getFirstColumnIndexOfType(meta, textTypes);
                             if (columnIndexOfType.isPresent()) {
                                 return row.getUuidFromString(columnIndexOfType.get());
                             }
-                            columnIndexOfType = Results.getColumnIndexOfType(meta, byteTypes);
+                            columnIndexOfType = Results.getFirstColumnIndexOfType(meta, byteTypes);
                             Integer index = columnIndexOfType.orElseThrow(() -> {
                                 List<SqlType> sqlTypes = new ArrayList<>(textTypes);
                                 sqlTypes.addAll(byteTypes);
@@ -82,7 +79,7 @@ public final class DefaultMapper {
         return RowMapper.forClass(clazz)
                         .mapper(row -> {
                             ResultSetMetaData meta = row.getMetaData();
-                            Optional<Integer> columnIndexOfType = Results.getColumnIndexOfType(meta, types);
+                            Optional<Integer> columnIndexOfType = Results.getFirstColumnIndexOfType(meta, types);
                             Integer index = columnIndexOfType.orElseThrow(() -> createException(types, meta));
                             return mapper.apply(row, index);
                         }).build();

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/DefaultMapper.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/DefaultMapper.java
@@ -1,0 +1,120 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2022 RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.mapper;
+
+import de.chojo.sadu.exceptions.ThrowingBiFunction;
+import de.chojo.sadu.types.SqlType;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
+import de.chojo.sadu.mapper.util.Results;
+import de.chojo.sadu.wrapper.util.Row;
+
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public final class DefaultMapper {
+    private DefaultMapper() {
+        throw new UnsupportedOperationException("This is a utility class.");
+    }
+
+    public static RowMapper<Integer> createInteger(List<SqlType> types) {
+        return create(Integer.class, Row::getInt, types);
+    }
+
+    public static RowMapper<Long> createLong(List<SqlType> types) {
+        return create(Long.class, Row::getLong, types);
+    }
+
+    public static RowMapper<Float> createFloat(List<SqlType> types) {
+        return create(Float.class, Row::getFloat, types);
+    }
+
+    public static RowMapper<Double> createDouble(List<SqlType> types) {
+        return create(Double.class, Row::getDouble, types);
+    }
+
+    public static RowMapper<String> createString(List<SqlType> types) {
+        return create(String.class, Row::getString, types);
+    }
+
+    public static RowMapper<Boolean> createBoolean(List<SqlType> types) {
+        return create(Boolean.class, Row::getBoolean, types);
+    }
+
+    public static RowMapper<Byte[]> createBytes(List<SqlType> types) {
+        return create(Byte[].class, (row, columnIndex) -> convertByteArray(row.getBytes(columnIndex)), types);
+    }
+
+    public static RowMapper<UUID> createUuid(List<SqlType> textTypes, List<SqlType> byteTypes) {
+        return RowMapper.forClass(java.util.UUID.class)
+                        .mapper(row -> {
+                            ResultSetMetaData meta = row.getMetaData();
+                            Optional<Integer> columnIndexOfType = Results.getColumnIndexOfType(meta, textTypes);
+                            if (columnIndexOfType.isPresent()) {
+                                return row.getUuidFromString(columnIndexOfType.get());
+                            }
+                            columnIndexOfType = Results.getColumnIndexOfType(meta, byteTypes);
+                            Integer index = columnIndexOfType.orElseThrow(() -> {
+                                List<SqlType> sqlTypes = new ArrayList<>(textTypes);
+                                sqlTypes.addAll(byteTypes);
+                                return createException(sqlTypes, meta);
+                            });
+                            return row.getUuidFromBytes(index);
+                        })
+                        .build();
+    }
+
+    public static <T> RowMapper<T> create(Class<T> clazz, ThrowingBiFunction<Row, Integer, T, SQLException> mapper, List<SqlType> types) {
+        return RowMapper.forClass(clazz)
+                        .mapper(row -> {
+                            ResultSetMetaData meta = row.getMetaData();
+                            Optional<Integer> columnIndexOfType = Results.getColumnIndexOfType(meta, types);
+                            Integer index = columnIndexOfType.orElseThrow(() -> createException(types, meta));
+                            return mapper.apply(row, index);
+                        }).build();
+    }
+
+    private static SQLException createException(List<SqlType> types, ResultSetMetaData meta) {
+        String type = types.stream().map(SqlType::descr)
+                              .collect(Collectors.joining(", "));
+        String available = "error";
+        try {
+            available = getColumnTypes(meta).entrySet().stream()
+                    .map(e -> "%s %s".formatted(e.getKey(), e.getValue()))
+                    .collect(Collectors.joining(", "));
+        } catch (SQLException e) {
+            // ignore
+        }
+        return new SQLException("No column of type %s present. Available: %s".formatted(type, available));
+    }
+
+    private static Map<String, String> getColumnTypes(ResultSetMetaData meta) throws SQLException {
+        Map<String, String> columns = new LinkedHashMap<>();
+        for (int i = 1; i <= meta.getColumnCount(); i++) {
+            columns.put(
+                    "%s | %s".formatted(i, meta.getColumnLabel(i)),
+                    "%s (%s)".formatted(meta.getColumnTypeName(i), meta.getColumnType(i)));
+        }
+        return columns;
+    }
+
+    private static Byte[] convertByteArray(byte[] primBytes) {
+        Byte[] bytes = new Byte[primBytes.length];
+        Arrays.setAll(bytes, n -> primBytes[n]);
+        return bytes;
+    }
+}

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/MapperConfig.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/MapperConfig.java
@@ -4,7 +4,7 @@
  *     Copyright (C) 2022 RainbowDashLabs and Contributor
  */
 
-package de.chojo.sadu.wrapper.mapper;
+package de.chojo.sadu.mapper;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/RowMapperRegistry.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/RowMapperRegistry.java
@@ -4,11 +4,12 @@
  *     Copyright (C) 2022 RainbowDashLabs and Contributor
  */
 
-package de.chojo.sadu.wrapper.mapper;
+package de.chojo.sadu.mapper;
 
-import de.chojo.sadu.wrapper.mapper.exceptions.MappingAlreadyRegisteredException;
-import de.chojo.sadu.wrapper.mapper.exceptions.MappingException;
-import de.chojo.sadu.wrapper.mapper.rowmapper.RowMapper;
+import de.chojo.sadu.mapper.exceptions.MappingAlreadyRegisteredException;
+import de.chojo.sadu.mapper.exceptions.MappingException;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
+import de.chojo.sadu.wrapper.util.Row;
 
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -56,6 +57,20 @@ public class RowMapperRegistry {
      * @throws MappingAlreadyRegisteredException when a mapping with the same column name exists already
      */
     public RowMapperRegistry register(RowMapper<?>... rowMapper) {
+        for (var mapper : rowMapper) {
+            register(mapper);
+        }
+        return this;
+    }
+    /**
+     * Registers new mapper.
+     * <p>
+     * A class can only have one mapper per column combination.
+     *
+     * @param rowMapper one or more mapper to register
+     * @throws MappingAlreadyRegisteredException when a mapping with the same column name exists already
+     */
+    public RowMapperRegistry register(List<RowMapper<?>> rowMapper) {
         for (var mapper : rowMapper) {
             register(mapper);
         }

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/exceptions/MappingAlreadyRegisteredException.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/exceptions/MappingAlreadyRegisteredException.java
@@ -4,7 +4,7 @@
  *     Copyright (C) 2022 RainbowDashLabs and Contributor
  */
 
-package de.chojo.sadu.wrapper.mapper.exceptions;
+package de.chojo.sadu.mapper.exceptions;
 
 public class MappingAlreadyRegisteredException extends RuntimeException {
     public MappingAlreadyRegisteredException(String message) {

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/exceptions/MappingException.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/exceptions/MappingException.java
@@ -4,9 +4,9 @@
  *     Copyright (C) 2022 RainbowDashLabs and Contributor
  */
 
-package de.chojo.sadu.wrapper.mapper.exceptions;
+package de.chojo.sadu.mapper.exceptions;
 
-import de.chojo.sadu.wrapper.mapper.util.Results;
+import de.chojo.sadu.mapper.util.Results;
 
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/rowmapper/PartialRowMapper.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/rowmapper/PartialRowMapper.java
@@ -4,7 +4,7 @@
  *     Copyright (C) 2022 RainbowDashLabs and Contributor
  */
 
-package de.chojo.sadu.wrapper.mapper.rowmapper;
+package de.chojo.sadu.mapper.rowmapper;
 
 import de.chojo.sadu.exceptions.ThrowingFunction;
 import de.chojo.sadu.wrapper.util.Row;

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/rowmapper/RowMapper.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/rowmapper/RowMapper.java
@@ -4,12 +4,13 @@
  *     Copyright (C) 2022 RainbowDashLabs and Contributor
  */
 
-package de.chojo.sadu.wrapper.mapper.rowmapper;
+package de.chojo.sadu.mapper.rowmapper;
 
 import de.chojo.sadu.exceptions.ThrowingFunction;
-import de.chojo.sadu.wrapper.mapper.MapperConfig;
+import de.chojo.sadu.mapper.MapperConfig;
 import de.chojo.sadu.wrapper.util.Row;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -17,7 +18,7 @@ import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.Set;
 
-import static de.chojo.sadu.wrapper.mapper.util.Results.columnNames;
+import static de.chojo.sadu.mapper.util.Results.columnNames;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -26,7 +27,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  * @param <T> type of retuned object
  */
 public class RowMapper<T> {
-    private static final Logger log = getLogger(RowMapper.class);
+    private static final Logger log = LoggerFactory.getLogger(RowMapper.class);
     private final Class<T> clazz;
     private final ThrowingFunction<? extends T, Row, SQLException> mapper;
     private final Set<String> columns;

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/rowmapper/RowMapperBuilder.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/rowmapper/RowMapperBuilder.java
@@ -4,7 +4,7 @@
  *     Copyright (C) 2022 RainbowDashLabs and Contributor
  */
 
-package de.chojo.sadu.wrapper.mapper.rowmapper;
+package de.chojo.sadu.mapper.rowmapper;
 
 import de.chojo.sadu.exceptions.ThrowingFunction;
 import de.chojo.sadu.wrapper.util.Row;

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/util/Results.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/util/Results.java
@@ -4,12 +4,16 @@
  *     Copyright (C) 2022 RainbowDashLabs and Contributor
  */
 
-package de.chojo.sadu.wrapper.mapper.util;
+package de.chojo.sadu.mapper.util;
+
+import de.chojo.sadu.types.SqlType;
 
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public final class Results {
@@ -41,5 +45,18 @@ public final class Results {
             columns.add(meta.getColumnLabel(i));
         }
         return columns;
+    }
+
+    public static Optional<Integer> getColumnIndexOfType(ResultSetMetaData meta, List<SqlType> types) throws SQLException {
+        for (int i = 1; i <= meta.getColumnCount(); i++) {
+            String typeName = meta.getColumnTypeName(i);
+            for (SqlType type : types) {
+                if (typeName.equalsIgnoreCase(type.name())) return Optional.of(i);
+                for (String alias : type.alias()) {
+                    if (typeName.equalsIgnoreCase(alias)) return Optional.of(i);
+                }
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/util/Results.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/util/Results.java
@@ -41,18 +41,26 @@ public final class Results {
      */
     public static Set<String> columnNames(ResultSetMetaData meta) throws SQLException {
         Set<String> columns = new HashSet<>();
-        for (int i = 1; i <= meta.getColumnCount(); i++) {
+        for (var i = 1; i <= meta.getColumnCount(); i++) {
             columns.add(meta.getColumnLabel(i));
         }
         return columns;
     }
 
-    public static Optional<Integer> getColumnIndexOfType(ResultSetMetaData meta, List<SqlType> types) throws SQLException {
-        for (int i = 1; i <= meta.getColumnCount(); i++) {
-            String typeName = meta.getColumnTypeName(i);
-            for (SqlType type : types) {
+    /**
+     * Extracts the column index (1 based) of the first column with the requested type.
+     *
+     * @param meta  meta of the result set
+     * @param types a list of valid types where the index will be returned
+     * @return the index of the column with the first type contained in types
+     * @throws SQLException if a database access error occurs
+     */
+    public static Optional<Integer> getFirstColumnIndexOfType(ResultSetMetaData meta, List<SqlType> types) throws SQLException {
+        for (var i = 1; i <= meta.getColumnCount(); i++) {
+            var typeName = meta.getColumnTypeName(i);
+            for (var type : types) {
                 if (typeName.equalsIgnoreCase(type.name())) return Optional.of(i);
-                for (String alias : type.alias()) {
+                for (var alias : type.alias()) {
                     if (typeName.equalsIgnoreCase(alias)) return Optional.of(i);
                 }
             }

--- a/sadu-mapper/src/main/java/de/chojo/sadu/wrapper/util/Row.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/wrapper/util/Row.java
@@ -8,7 +8,7 @@ package de.chojo.sadu.wrapper.util;
 
 import de.chojo.sadu.conversion.ArrayConverter;
 import de.chojo.sadu.conversion.UUIDConverter;
-import de.chojo.sadu.wrapper.mapper.MapperConfig;
+import de.chojo.sadu.mapper.MapperConfig;
 
 import java.io.InputStream;
 import java.io.Reader;

--- a/sadu-mariadb/build.gradle.kts
+++ b/sadu-mariadb/build.gradle.kts
@@ -1,3 +1,7 @@
 dependencies {
     api(project(":sadu-core"))
+    api(project(":sadu-mapper"))
+
+    testImplementation("org.mariadb.jdbc:mariadb-java-client:3.0.7")
+    testImplementation(project(":sadu-queries"))
 }

--- a/sadu-mariadb/src/main/java/de/chojo/sadu/mapper/MariaDbMapper.java
+++ b/sadu-mariadb/src/main/java/de/chojo/sadu/mapper/MariaDbMapper.java
@@ -1,0 +1,60 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2022 RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.mapper;
+
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
+
+import java.util.List;
+import java.util.UUID;
+
+import static de.chojo.sadu.mapper.DefaultMapper.createBoolean;
+import static de.chojo.sadu.mapper.DefaultMapper.createBytes;
+import static de.chojo.sadu.mapper.DefaultMapper.createDouble;
+import static de.chojo.sadu.mapper.DefaultMapper.createFloat;
+import static de.chojo.sadu.mapper.DefaultMapper.createInteger;
+import static de.chojo.sadu.mapper.DefaultMapper.createLong;
+import static de.chojo.sadu.mapper.DefaultMapper.createString;
+import static de.chojo.sadu.mapper.DefaultMapper.createUuid;
+import static de.chojo.sadu.types.MariaDbTypes.BIGINT;
+import static de.chojo.sadu.types.MariaDbTypes.BLOB;
+import static de.chojo.sadu.types.MariaDbTypes.BOOLEAN;
+import static de.chojo.sadu.types.MariaDbTypes.DECIMAL;
+import static de.chojo.sadu.types.MariaDbTypes.DOUBLE;
+import static de.chojo.sadu.types.MariaDbTypes.FLOAT;
+import static de.chojo.sadu.types.MariaDbTypes.INT;
+import static de.chojo.sadu.types.MariaDbTypes.LONGBLOB;
+import static de.chojo.sadu.types.MariaDbTypes.LONGTEXT;
+import static de.chojo.sadu.types.MariaDbTypes.MEDIUMBLOB;
+import static de.chojo.sadu.types.MariaDbTypes.MEDIUMINT;
+import static de.chojo.sadu.types.MariaDbTypes.MEDIUMTEXT;
+import static de.chojo.sadu.types.MariaDbTypes.SMALLINT;
+import static de.chojo.sadu.types.MariaDbTypes.TEXT;
+import static de.chojo.sadu.types.MariaDbTypes.TINYBLOB;
+import static de.chojo.sadu.types.MariaDbTypes.TINYINT;
+import static de.chojo.sadu.types.MariaDbTypes.TINYTEXT;
+import static de.chojo.sadu.types.MariaDbTypes.VARBINARY;
+import static de.chojo.sadu.types.MariaDbTypes.VARCHAR;
+
+public final class MariaDbMapper {
+    private MariaDbMapper() {
+        throw new UnsupportedOperationException("This is a utility class.");
+    }
+
+    public static final RowMapper<Boolean> BOOLEAN_MAPPER = createBoolean(List.of(BOOLEAN));
+    public static final RowMapper<Integer> INTEGER_MAPPER = createInteger(List.of(TINYINT, SMALLINT, MEDIUMINT, INT));
+    public static final RowMapper<Long> LONG_MAPPER = createLong(List.of(BIGINT, TINYINT, SMALLINT, MEDIUMINT, INT));
+    public static final RowMapper<Float> FLOAT_MAPPER = createFloat(List.of(DOUBLE, DECIMAL, FLOAT));
+    public static final RowMapper<Double> DOUBLE_MAPPER = createDouble(List.of(DOUBLE, DECIMAL, FLOAT));
+    public static final RowMapper<String> STRING_MAPPER = createString(List.of(TINYTEXT, TEXT, MEDIUMTEXT, LONGTEXT, VARCHAR));
+    public static final RowMapper<Byte[]> BYTES_MAPPER = createBytes(List.of(TINYTEXT, TEXT, MEDIUMTEXT, LONGTEXT, VARCHAR));
+    public static final RowMapper<UUID> UUID_MAPPER = createUuid(List.of(TINYTEXT, TEXT, MEDIUMTEXT, LONGTEXT, VARCHAR),
+            List.of(TINYBLOB, BLOB, MEDIUMBLOB, LONGBLOB, VARBINARY));
+
+    public static List<RowMapper<?>> getDefaultMapper(){
+        return List.of(BOOLEAN_MAPPER, INTEGER_MAPPER, LONG_MAPPER, FLOAT_MAPPER, DOUBLE_MAPPER, STRING_MAPPER, BYTES_MAPPER, UUID_MAPPER);
+    }
+}

--- a/sadu-mariadb/src/main/java/de/chojo/sadu/types/MariaDbTypes.java
+++ b/sadu-mariadb/src/main/java/de/chojo/sadu/types/MariaDbTypes.java
@@ -54,7 +54,7 @@ public interface MariaDbTypes {
     /**
      * -2,147,483,648 and 2,147,483,647
      */
-    SqlType INT = ofName("INT");
+    SqlType INT = ofName("INT", "INTEGER");
     /**
      * "Unlimited"
      */
@@ -76,7 +76,7 @@ public interface MariaDbTypes {
     /**
      * Boolean representation
      */
-    SqlType BOOLEAN = ofName("BOOLEAN");
+    SqlType BOOLEAN = ofName("BOOLEAN", "INTEGER");
 
     /**
      * Fixed {@literal <} 255 with padding

--- a/sadu-mariadb/src/test/java/de/chojo/sadu/jdbc/MariaDbJdbcTest.java
+++ b/sadu-mariadb/src/test/java/de/chojo/sadu/jdbc/MariaDbJdbcTest.java
@@ -7,6 +7,9 @@
 package de.chojo.sadu.jdbc;
 
 import de.chojo.sadu.databases.MariaDb;
+import de.chojo.sadu.mapper.MariaDbMapper;
+import de.chojo.sadu.mapper.RowMapperRegistry;
+import de.chojo.sadu.wrapper.QueryBuilderConfig;
 import org.junit.jupiter.api.BeforeEach;
 
 class MariaDbJdbcTest {

--- a/sadu-mariadb/src/test/java/de/chojo/sadu/mapper/MariaDbMapperTest.java
+++ b/sadu-mariadb/src/test/java/de/chojo/sadu/mapper/MariaDbMapperTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class MariaDbMapperTest {
 
     @Test
-    //@Disabled
+    @Disabled
     public void test() throws SQLException {
         MariaDbDataSource dataSource = new MariaDbDataSource(MariaDb.get().jdbcBuilder().login("root", "root").jdbcUrl());
 

--- a/sadu-mariadb/src/test/java/de/chojo/sadu/mapper/MariaDbMapperTest.java
+++ b/sadu-mariadb/src/test/java/de/chojo/sadu/mapper/MariaDbMapperTest.java
@@ -1,0 +1,52 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2022 RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.mapper;
+
+import de.chojo.sadu.base.QueryFactory;
+import de.chojo.sadu.databases.MariaDb;
+import de.chojo.sadu.wrapper.QueryBuilder;
+import de.chojo.sadu.wrapper.QueryBuilderConfig;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.mariadb.jdbc.MariaDbDataSource;
+
+import java.sql.SQLException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MariaDbMapperTest {
+
+    @Test
+    //@Disabled
+    public void test() throws SQLException {
+        MariaDbDataSource dataSource = new MariaDbDataSource(MariaDb.get().jdbcBuilder().login("root", "root").jdbcUrl());
+
+        RowMapperRegistry registry = new RowMapperRegistry().register(MariaDbMapper.getDefaultMapper());
+
+        QueryBuilderConfig.setDefault(QueryBuilderConfig.builder().rowMappers(registry).build());
+
+        QueryFactory queryFactory = new QueryFactory(dataSource);
+
+        Optional<Integer> integer = queryFactory.builder(Integer.class)
+                .query("SELECT 1")
+                .emptyParams()
+                .map()
+                .firstSync();
+
+        assertTrue(integer.isPresent());
+
+        Optional<Boolean> bool = queryFactory.builder(Boolean.class)
+                .query("SELECT TRUE")
+                .emptyParams()
+                .map()
+                .firstSync();
+
+        assertTrue(bool.isPresent());
+    }
+
+}

--- a/sadu-mysql/build.gradle.kts
+++ b/sadu-mysql/build.gradle.kts
@@ -1,3 +1,4 @@
 dependencies {
     api(project(":sadu-core"))
+    api(project(":sadu-mapper"))
 }

--- a/sadu-mysql/src/main/java/de/chojo/sadu/mapper/MySqlMapper.java
+++ b/sadu-mysql/src/main/java/de/chojo/sadu/mapper/MySqlMapper.java
@@ -1,0 +1,60 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2022 RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.mapper;
+
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
+
+import java.util.List;
+import java.util.UUID;
+
+import static de.chojo.sadu.mapper.DefaultMapper.createBoolean;
+import static de.chojo.sadu.mapper.DefaultMapper.createBytes;
+import static de.chojo.sadu.mapper.DefaultMapper.createDouble;
+import static de.chojo.sadu.mapper.DefaultMapper.createFloat;
+import static de.chojo.sadu.mapper.DefaultMapper.createInteger;
+import static de.chojo.sadu.mapper.DefaultMapper.createLong;
+import static de.chojo.sadu.mapper.DefaultMapper.createString;
+import static de.chojo.sadu.mapper.DefaultMapper.createUuid;
+import static de.chojo.sadu.types.MySqlTypes.BIGINT;
+import static de.chojo.sadu.types.MySqlTypes.BLOB;
+import static de.chojo.sadu.types.MySqlTypes.BOOLEAN;
+import static de.chojo.sadu.types.MySqlTypes.DECIMAL;
+import static de.chojo.sadu.types.MySqlTypes.DOUBLE;
+import static de.chojo.sadu.types.MySqlTypes.FLOAT;
+import static de.chojo.sadu.types.MySqlTypes.INT;
+import static de.chojo.sadu.types.MySqlTypes.LONGBLOB;
+import static de.chojo.sadu.types.MySqlTypes.LONGTEXT;
+import static de.chojo.sadu.types.MySqlTypes.MEDIUMBLOB;
+import static de.chojo.sadu.types.MySqlTypes.MEDIUMINT;
+import static de.chojo.sadu.types.MySqlTypes.MEDIUMTEXT;
+import static de.chojo.sadu.types.MySqlTypes.SMALLINT;
+import static de.chojo.sadu.types.MySqlTypes.TEXT;
+import static de.chojo.sadu.types.MySqlTypes.TINYBLOB;
+import static de.chojo.sadu.types.MySqlTypes.TINYINT;
+import static de.chojo.sadu.types.MySqlTypes.TINYTEXT;
+import static de.chojo.sadu.types.MySqlTypes.VARBINARY;
+import static de.chojo.sadu.types.MySqlTypes.VARCHAR;
+
+public final class MySqlMapper {
+    private MySqlMapper() {
+        throw new UnsupportedOperationException("This is a utility class.");
+    }
+
+    public static final RowMapper<Boolean> BOOLEAN_MAPPER = createBoolean(List.of(BOOLEAN));
+    public static final RowMapper<Integer> INTEGER_MAPPER = createInteger(List.of(TINYINT, SMALLINT, MEDIUMINT, INT));
+    public static final RowMapper<Long> LONG_MAPPER = createLong(List.of(BIGINT, TINYINT, SMALLINT, MEDIUMINT, INT));
+    public static final RowMapper<Float> FLOAT_MAPPER = createFloat(List.of(DOUBLE, DECIMAL, FLOAT));
+    public static final RowMapper<Double> DOUBLE_MAPPER = createDouble(List.of(DOUBLE, DECIMAL, FLOAT));
+    public static final RowMapper<String> STRING_MAPPER = createString(List.of(TINYTEXT, TEXT, MEDIUMTEXT, LONGTEXT, VARCHAR));
+    public static final RowMapper<Byte[]> BYTES_MAPPER = createBytes(List.of(TINYTEXT, TEXT, MEDIUMTEXT, LONGTEXT, VARCHAR));
+    public static final RowMapper<UUID> UUID_MAPPER = createUuid(List.of(TINYTEXT, TEXT, MEDIUMTEXT, LONGTEXT, VARCHAR),
+            List.of(TINYBLOB, BLOB, MEDIUMBLOB, LONGBLOB, VARBINARY));
+
+    public static List<RowMapper<?>> getDefaultMapper(){
+        return List.of(BOOLEAN_MAPPER, INTEGER_MAPPER, LONG_MAPPER, FLOAT_MAPPER, DOUBLE_MAPPER, STRING_MAPPER, BYTES_MAPPER, UUID_MAPPER);
+    }
+}

--- a/sadu-mysql/src/main/java/de/chojo/sadu/types/MySqlTypes.java
+++ b/sadu-mysql/src/main/java/de/chojo/sadu/types/MySqlTypes.java
@@ -54,7 +54,7 @@ public interface MySqlTypes {
     /**
      * -2,147,483,648 and 2,147,483,647
      */
-    SqlType INT = ofName("INT");
+    SqlType INT = ofName("INT", "INTEGER");
     /**
      * "Unlimited"
      */
@@ -76,7 +76,7 @@ public interface MySqlTypes {
     /**
      * Boolean representation
      */
-    SqlType BOOLEAN = ofName("BOOLEAN");
+    SqlType BOOLEAN = ofName("BOOLEAN", "INTEGER");
 
     /**
      * Fixed {@literal <} 255 with padding

--- a/sadu-postgresql/build.gradle.kts
+++ b/sadu-postgresql/build.gradle.kts
@@ -1,3 +1,4 @@
 dependencies {
     api(project(":sadu-core"))
+    api(project(":sadu-mapper"))
 }

--- a/sadu-postgresql/src/main/java/de/chojo/sadu/mapper/PostgresqlMapper.java
+++ b/sadu-postgresql/src/main/java/de/chojo/sadu/mapper/PostgresqlMapper.java
@@ -1,0 +1,51 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2022 RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.mapper;
+
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
+
+import java.util.List;
+import java.util.UUID;
+
+import static de.chojo.sadu.mapper.DefaultMapper.createBoolean;
+import static de.chojo.sadu.mapper.DefaultMapper.createBytes;
+import static de.chojo.sadu.mapper.DefaultMapper.createDouble;
+import static de.chojo.sadu.mapper.DefaultMapper.createFloat;
+import static de.chojo.sadu.mapper.DefaultMapper.createInteger;
+import static de.chojo.sadu.mapper.DefaultMapper.createLong;
+import static de.chojo.sadu.mapper.DefaultMapper.createString;
+import static de.chojo.sadu.mapper.DefaultMapper.createUuid;
+import static de.chojo.sadu.types.PostgreSqlTypes.BIGINT;
+import static de.chojo.sadu.types.PostgreSqlTypes.BOOLEAN;
+import static de.chojo.sadu.types.PostgreSqlTypes.BYTEA;
+import static de.chojo.sadu.types.PostgreSqlTypes.CHAR;
+import static de.chojo.sadu.types.PostgreSqlTypes.DECIMAL;
+import static de.chojo.sadu.types.PostgreSqlTypes.DOUBLE;
+import static de.chojo.sadu.types.PostgreSqlTypes.INTEGER;
+import static de.chojo.sadu.types.PostgreSqlTypes.NUMERIC;
+import static de.chojo.sadu.types.PostgreSqlTypes.SMALLINT;
+import static de.chojo.sadu.types.PostgreSqlTypes.TEXT;
+import static de.chojo.sadu.types.PostgreSqlTypes.VARCHAR;
+
+public final class PostgresqlMapper {
+    private PostgresqlMapper() {
+        throw new UnsupportedOperationException("This is a utility class.");
+    }
+
+    public static final RowMapper<Boolean> BOOLEAN_MAPPER = createBoolean(List.of(BOOLEAN));
+    public static final RowMapper<Integer> INTEGER_MAPPER = createInteger(List.of(SMALLINT, INTEGER));
+    public static final RowMapper<Long> LONG_MAPPER = createLong(List.of(SMALLINT, INTEGER, BIGINT));
+    public static final RowMapper<Float> FLOAT_MAPPER = createFloat(List.of(DECIMAL, NUMERIC, DOUBLE));
+    public static final RowMapper<Double> DOUBLE_MAPPER = createDouble(List.of(DECIMAL, NUMERIC, DOUBLE));
+    public static final RowMapper<String> STRING_MAPPER = createString(List.of(TEXT, VARCHAR, CHAR));
+    public static final RowMapper<Byte[]> BYTES_MAPPER = createBytes(List.of(BYTEA));
+    public static final RowMapper<UUID> UUID_MAPPER = createUuid(List.of(TEXT), List.of(BYTEA));
+
+    public static List<RowMapper<?>> getDefaultMapper() {
+        return List.of(BOOLEAN_MAPPER, INTEGER_MAPPER, LONG_MAPPER, FLOAT_MAPPER, DOUBLE_MAPPER, STRING_MAPPER, BYTES_MAPPER, UUID_MAPPER);
+    }
+}

--- a/sadu-queries/build.gradle.kts
+++ b/sadu-queries/build.gradle.kts
@@ -5,5 +5,6 @@ dependencies {
 
     testImplementation(project(":sadu-datasource"))
     testImplementation(project(":sadu-sqlite"))
+    testImplementation(project(":sadu-mapper"))
     testImplementation("org.xerial", "sqlite-jdbc", "3.39.2.0")
 }

--- a/sadu-queries/build.gradle.kts
+++ b/sadu-queries/build.gradle.kts
@@ -1,6 +1,7 @@
 
 dependencies {
     api(project(":sadu-core"))
+    api(project(":sadu-mapper"))
 
     testImplementation(project(":sadu-datasource"))
     testImplementation(project(":sadu-sqlite"))

--- a/sadu-queries/src/main/java/de/chojo/sadu/wrapper/QueryBuilder.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/wrapper/QueryBuilder.java
@@ -9,10 +9,10 @@ package de.chojo.sadu.wrapper;
 import de.chojo.sadu.base.DataHolder;
 import de.chojo.sadu.exceptions.ThrowingConsumer;
 import de.chojo.sadu.exceptions.ThrowingFunction;
+import de.chojo.sadu.mapper.MapperConfig;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.wrapper.exception.QueryExecutionException;
 import de.chojo.sadu.wrapper.exception.WrappedQueryExecutionException;
-import de.chojo.sadu.wrapper.mapper.MapperConfig;
-import de.chojo.sadu.wrapper.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.wrapper.stage.ConfigurationStage;
 import de.chojo.sadu.wrapper.stage.InsertStage;
 import de.chojo.sadu.wrapper.stage.QueryStage;
@@ -167,6 +167,7 @@ public class QueryBuilder<T> extends DataHolder implements ConfigurationStage<T>
     public RetrievalStage<T> map(MapperConfig mapperConfig) {
         Objects.requireNonNull(clazz);
         this.mapperConfig = mapperConfig.clone();
+        queueTask();
         return this;
     }
 

--- a/sadu-queries/src/main/java/de/chojo/sadu/wrapper/QueryBuilderConfig.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/wrapper/QueryBuilderConfig.java
@@ -8,9 +8,9 @@ package de.chojo.sadu.wrapper;
 
 import de.chojo.sadu.base.QueryFactory;
 import de.chojo.sadu.exceptions.ExceptionTransformer;
+import de.chojo.sadu.mapper.RowMapperRegistry;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.wrapper.exception.QueryExecutionException;
-import de.chojo.sadu.wrapper.mapper.RowMapperRegistry;
-import de.chojo.sadu.wrapper.mapper.rowmapper.RowMapper;
 import org.jetbrains.annotations.NotNull;
 
 import java.sql.SQLException;

--- a/sadu-queries/src/main/java/de/chojo/sadu/wrapper/stage/ResultStage.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/wrapper/stage/ResultStage.java
@@ -7,9 +7,9 @@
 package de.chojo.sadu.wrapper.stage;
 
 import de.chojo.sadu.exceptions.ThrowingFunction;
+import de.chojo.sadu.mapper.MapperConfig;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.wrapper.QueryBuilder;
-import de.chojo.sadu.wrapper.mapper.MapperConfig;
-import de.chojo.sadu.wrapper.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.wrapper.util.Row;
 
 import java.sql.SQLException;

--- a/sadu-queries/src/test/java/de/chojo/sadu/wrapper/mapper/Mapper.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/wrapper/mapper/Mapper.java
@@ -6,7 +6,7 @@
 
 package de.chojo.sadu.wrapper.mapper;
 
-import de.chojo.sadu.wrapper.mapper.rowmapper.RowMapper;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
 
 public class Mapper {
     public static final RowMapper<Result> wildcard = RowMapper.forClass(Result.class)

--- a/sadu-queries/src/test/java/de/chojo/sadu/wrapper/mapper/RowMapperRegistryTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/wrapper/mapper/RowMapperRegistryTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RowMapperRegistryTest {

--- a/sadu-queries/src/test/java/de/chojo/sadu/wrapper/mapper/RowMapperRegistryTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/wrapper/mapper/RowMapperRegistryTest.java
@@ -6,12 +6,15 @@
 
 package de.chojo.sadu.wrapper.mapper;
 
+import de.chojo.sadu.mapper.MapperConfig;
+import de.chojo.sadu.mapper.RowMapperRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RowMapperRegistryTest {

--- a/sadu-queries/src/test/java/de/chojo/sadu/wrapper/mapper/RowMapperTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/wrapper/mapper/RowMapperTest.java
@@ -6,8 +6,10 @@
 
 package de.chojo.sadu.wrapper.mapper;
 
+import de.chojo.sadu.mapper.MapperConfig;
+import de.chojo.sadu.mapper.RowMapperRegistry;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.wrapper.QueryBuilder;
-import de.chojo.sadu.wrapper.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.wrapper.util.Row;
 import org.junit.jupiter.api.Test;
 

--- a/sadu-sqlite/src/main/java/de/chojo/sadu/mapper/SqLiteMapper.java
+++ b/sadu-sqlite/src/main/java/de/chojo/sadu/mapper/SqLiteMapper.java
@@ -1,0 +1,41 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2022 RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.mapper;
+
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
+
+import java.util.List;
+import java.util.UUID;
+
+import static de.chojo.sadu.mapper.DefaultMapper.createBoolean;
+import static de.chojo.sadu.mapper.DefaultMapper.createBytes;
+import static de.chojo.sadu.mapper.DefaultMapper.createDouble;
+import static de.chojo.sadu.mapper.DefaultMapper.createFloat;
+import static de.chojo.sadu.mapper.DefaultMapper.createInteger;
+import static de.chojo.sadu.mapper.DefaultMapper.createLong;
+import static de.chojo.sadu.mapper.DefaultMapper.createString;
+import static de.chojo.sadu.mapper.DefaultMapper.createUuid;
+import static de.chojo.sadu.types.SqLiteTypes.*;
+
+public final class SqLiteMapper {
+    private SqLiteMapper() {
+        throw new UnsupportedOperationException("This is a utility class.");
+    }
+
+    public static final RowMapper<Boolean> BOOLEAN_MAPPER = createBoolean(List.of(BOOLEAN));
+    public static final RowMapper<Integer> INTEGER_MAPPER = createInteger(List.of(INTEGER));
+    public static final RowMapper<Long> LONG_MAPPER = createLong(List.of(INTEGER));
+    public static final RowMapper<Float> FLOAT_MAPPER = createFloat(List.of(REAL));
+    public static final RowMapper<Double> DOUBLE_MAPPER = createDouble(List.of(REAL));
+    public static final RowMapper<String> STRING_MAPPER = createString(List.of(TEXT));
+    public static final RowMapper<Byte[]> BYTES_MAPPER = createBytes(List.of(BLOB));
+    public static final RowMapper<UUID> UUID_MAPPER = createUuid(List.of(TEXT), List.of(BLOB));
+
+    public static List<RowMapper<?>> getDefaultMapper() {
+        return List.of(BOOLEAN_MAPPER, INTEGER_MAPPER, LONG_MAPPER, FLOAT_MAPPER, DOUBLE_MAPPER, STRING_MAPPER, BYTES_MAPPER, UUID_MAPPER);
+    }
+}

--- a/sadu-sqlite/src/main/java/de/chojo/sadu/types/SqLiteTypes.java
+++ b/sadu-sqlite/src/main/java/de/chojo/sadu/types/SqLiteTypes.java
@@ -28,9 +28,9 @@ public interface SqLiteTypes {
      * SqLite boolean type
      * Internally interpreted as an INTEGER
      */
-    SqlType BOOLEAN = ofName("BOOLEAN");
+    SqlType BOOLEAN = ofName("BOOLEAN", "INTEGER");
     /**
      * SqLite blob type
      */
-    SqlType BLOB = ofName("BOOLEAN");
+    SqlType BLOB = ofName("BLOB");
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,3 +22,4 @@ pluginManagement{
         }
     }
 }
+include("sadu-mapper")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ include("sadu-mysql")
 include("sadu-datasource")
 include("sadu-queries")
 include("sadu-updater")
-
+include("sadu-mapper")
 include("sadu-examples")
 
 pluginManagement{
@@ -22,4 +22,3 @@ pluginManagement{
         }
     }
 }
-include("sadu-mapper")


### PR DESCRIPTION
Implements mapper which can be easily registered.
These can be used for single column result sets or for a result set with only one matching column for this type.

Mappers were moved to their own module.

We could probably add mapper for the java 8 time api and other stuff in the future as well. but for now keep a minimal example.