### PR TITLE
Feature/check return type

### DIFF
--- a/sadu-core/build.gradle.kts
+++ b/sadu-core/build.gradle.kts
@@ -1,4 +1,5 @@
 dependencies {
     api("org.slf4j", "slf4j-api", "1.7.36")
     api("org.jetbrains", "annotations", "23.0.0")
+    api("com.google.code.findbugs", "jsr305", "3.0.2")
 }

--- a/sadu-core/src/main/java/de/chojo/sadu/exceptions/ThrowingBiFunction.java
+++ b/sadu-core/src/main/java/de/chojo/sadu/exceptions/ThrowingBiFunction.java
@@ -1,0 +1,27 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2022 RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.exceptions;
+
+/**
+ * Represents a function which can throw an exception.
+ * <p>
+ * this is usefull when you need to delegate checked exceptions
+ *
+ * @param <R> type of result
+ * @param <T> type of input
+ * @param <E> type of exception
+ */
+public interface ThrowingBiFunction<T, U, R, E extends Exception> {
+    /**
+     * A function which maps a value to another value and can throw an exception
+     *
+     * @param t input
+     * @return value
+     * @throws E if something went wrong
+     */
+    R apply(T t, U u) throws E;
+}

--- a/sadu-core/src/main/java/de/chojo/sadu/jdbc/JdbcConfig.java
+++ b/sadu-core/src/main/java/de/chojo/sadu/jdbc/JdbcConfig.java
@@ -8,6 +8,7 @@ package de.chojo.sadu.jdbc;
 
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.CheckReturnValue;
 import java.sql.Driver;
 import java.util.LinkedHashSet;
 import java.util.Optional;

--- a/sadu-core/src/main/java/de/chojo/sadu/jdbc/RemoteJdbcConfig.java
+++ b/sadu-core/src/main/java/de/chojo/sadu/jdbc/RemoteJdbcConfig.java
@@ -17,7 +17,7 @@ public abstract class RemoteJdbcConfig<T extends RemoteJdbcConfig<?>> extends Jd
     private static final Pattern IPV4 = Pattern.compile("^(?:\\d{1,3}\\.){3}\\d{1,3}$");
     private static final Pattern IPV6 = Pattern.compile(
             "(([\\da-fA-F]{1,4}:){7}[\\da-fA-F]{1,4}|([\\da-fA-F]{1,4}:){1,7}:|([\\da-fA-F]{1,4}:){1,6}:[\\da-fA-F]{1,4}|([\\da-fA-F]{1,4}:){1,5}(:[\\da-fA-F]{1,4}){1,2}|([\\da-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([\\da-fA-F]{1,4}:){1,3}(:[\\da-fA-F]{1,4}){1,4}|([\\da-fA-F]{1,4}:){1,2}(:[\\da-fA-F]{1,4}){1,5}|[\\da-fA-F]{1,4}:((:[\\da-fA-F]{1,4}){1,6})|:((:[\\da-fA-F]{1,4}){1,7}|:)|fe80:(:[\\da-fA-F]{0,4}){0,4}%[\\da-zA-Z]+|::(ffff(:0{1,4})?:)?((25[0-5]|(2[0-4]|1?\\d)?\\d)\\.){3}(25[0-5]|(2[0-4]|1?\\d)?\\d)|([\\da-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1?\\d)?\\d)\\.){3}(25[0-5]|(2[0-4]|1?\\d)?\\d))");
-    private String host;
+    private String host = "localhost";
     private String port;
     private String database;
 

--- a/sadu-core/src/main/java/de/chojo/sadu/types/SqlType.java
+++ b/sadu-core/src/main/java/de/chojo/sadu/types/SqlType.java
@@ -9,7 +9,6 @@ package de.chojo.sadu.types;
 /**
  * Represents a named data type in a database.
  */
-@FunctionalInterface
 public interface SqlType {
     /**
      * Creates a new sql type with a name
@@ -17,8 +16,18 @@ public interface SqlType {
      * @param name name
      * @return new type
      */
-    static SqlType ofName(String name) {
-        return () -> name;
+    static SqlType ofName(String name, String... alias) {
+        return new SqlType() {
+            @Override
+            public String name() {
+                return name;
+            }
+
+            @Override
+            public String[] alias() {
+                return alias;
+            }
+        };
     }
 
     /**
@@ -27,4 +36,21 @@ public interface SqlType {
      * @return type
      */
     String name();
+
+    /**
+     * Alias for a type.
+     * <p>
+     * E.g. INTEGER for INT
+     *
+     * @return array of aliase for this type
+     */
+    String[] alias();
+
+    default String descr() {
+        if (alias().length == 0) {
+            return name();
+        }
+        return "%s (%s)".formatted(name(), String.join(", ", alias()));
+    }
+
 }

--- a/sadu-core/src/test/java/de/chojo/sadu/jdbc/RemoteJdbcConfigTest.java
+++ b/sadu-core/src/test/java/de/chojo/sadu/jdbc/RemoteJdbcConfigTest.java
@@ -32,13 +32,13 @@ class RemoteJdbcConfigTest {
     @Test
     void testDatabase() {
         var jdbcUrl = jdbc.database("database").jdbcUrl();
-        Assertions.assertEquals("jdbc:driver:database", jdbcUrl);
+        Assertions.assertEquals("jdbc:driver://localhost/database", jdbcUrl);
     }
 
     @Test
     void testNone() {
         var jdbcUrl = jdbc.jdbcUrl();
-        Assertions.assertEquals("jdbc:driver:/", jdbcUrl);
+        Assertions.assertEquals("jdbc:driver://localhost/", jdbcUrl);
     }
 
     @Test
@@ -56,7 +56,6 @@ class RemoteJdbcConfigTest {
     @Test
     void testPort() {
         jdbc.port(1234);
-        Assertions.assertThrows(IllegalStateException.class, () -> jdbc.jdbcUrl());
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> jdbc.port(0));
         Assertions.assertThrows(IllegalArgumentException.class, () -> jdbc.port("0"));

--- a/sadu-datasource/src/main/java/de/chojo/sadu/datasource/DataSourceCreator.java
+++ b/sadu-datasource/src/main/java/de/chojo/sadu/datasource/DataSourceCreator.java
@@ -15,6 +15,7 @@ import de.chojo.sadu.jdbc.JdbcConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.CheckReturnValue;
 import javax.sql.DataSource;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -41,17 +42,20 @@ public class DataSourceCreator<T extends JdbcConfig<?>> implements JdbcStage<T>,
      * @param <T>  database type defined by the {@link Database}
      * @return a {@link DataSourceCreator} in {@link JdbcStage}.
      */
+    @CheckReturnValue
     public static <T extends JdbcConfig<?>> JdbcStage<T> create(Database<T> type) {
         return new DataSourceCreator<>(type);
     }
 
     @Override
+    @CheckReturnValue
     public JdbcStage<T> configure(Consumer<T> builder) {
         builder.accept(this.builder);
         return this;
     }
 
     @Override
+    @CheckReturnValue
     public ConfigurationStage create() {
         loadDriverClass();
         var jdbcUrl = builder.jdbcUrl();
@@ -70,90 +74,105 @@ public class DataSourceCreator<T extends JdbcConfig<?>> implements JdbcStage<T>,
     }
 
     @Override
+    @CheckReturnValue
     public ConfigurationStage withConnectionTimeout(long connectionTimeoutMs) {
         hikariConfig.setConnectionTimeout(connectionTimeoutMs);
         return this;
     }
 
     @Override
+    @CheckReturnValue
     public ConfigurationStage withIdleTimeout(long idleTimeoutMs) {
         hikariConfig.setIdleTimeout(idleTimeoutMs);
         return this;
     }
 
     @Override
+    @CheckReturnValue
     public ConfigurationStage withMaxLifetime(long maxLifetimeMs) {
         hikariConfig.setMaxLifetime(maxLifetimeMs);
         return this;
     }
 
     @Override
+    @CheckReturnValue
     public ConfigurationStage withMaximumPoolSize(int maxPoolSize) {
         hikariConfig.setMaximumPoolSize(maxPoolSize);
         return this;
     }
 
     @Override
+    @CheckReturnValue
     public ConfigurationStage withMinimumIdle(int minIdle) {
         hikariConfig.setMinimumIdle(minIdle);
         return this;
     }
 
     @Override
+    @CheckReturnValue
     public ConfigurationStage usingPassword(String password) {
         hikariConfig.setPassword(password);
         return this;
     }
 
     @Override
+    @CheckReturnValue
     public ConfigurationStage usingUsername(String username) {
         hikariConfig.setUsername(username);
         return this;
     }
 
     @Override
+    @CheckReturnValue
     public DataSourceCreator<T> withDataSourceClassName(Class<? extends DataSource> className) {
         hikariConfig.setDataSourceClassName(className.getName());
         return this;
     }
 
     @Override
+    @CheckReturnValue
     public ConfigurationStage withAutoCommit(boolean isAutoCommit) {
         hikariConfig.setAutoCommit(isAutoCommit);
         return this;
     }
 
     @Override
+    @CheckReturnValue
     public ConfigurationStage withKeepaliveTime(long keepaliveTimeMs) {
         hikariConfig.setKeepaliveTime(keepaliveTimeMs);
         return this;
     }
 
     @Override
+    @CheckReturnValue
     public ConfigurationStage withPoolName(String poolName) {
         hikariConfig.setPoolName(poolName);
         return this;
     }
 
     @Override
+    @CheckReturnValue
     public ConfigurationStage withScheduledExecutor(ScheduledExecutorService executor) {
         hikariConfig.setScheduledExecutor(executor);
         return this;
     }
 
     @Override
+    @CheckReturnValue
     public ConfigurationStage forSchema(String schema) {
         hikariConfig.setSchema(schema);
         return this;
     }
 
     @Override
+    @CheckReturnValue
     public ConfigurationStage withThreadFactory(ThreadFactory threadFactory) {
         hikariConfig.setThreadFactory(threadFactory);
         return this;
     }
 
     @Override
+    @CheckReturnValue
     public HikariDataSource build() {
         return new HikariDataSource(hikariConfig);
     }

--- a/sadu-datasource/src/main/java/de/chojo/sadu/datasource/stage/ConfigurationStage.java
+++ b/sadu-datasource/src/main/java/de/chojo/sadu/datasource/stage/ConfigurationStage.java
@@ -8,6 +8,7 @@ package de.chojo.sadu.datasource.stage;
 
 import com.zaxxer.hikari.HikariDataSource;
 
+import javax.annotation.CheckReturnValue;
 import javax.sql.DataSource;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -23,6 +24,7 @@ public interface ConfigurationStage {
      * @param connectionTimeoutMs the connection timeout in milliseconds
      * @return Configuration Stage with value set.
      */
+    @CheckReturnValue
     ConfigurationStage withConnectionTimeout(long connectionTimeoutMs);
 
     /**
@@ -34,6 +36,7 @@ public interface ConfigurationStage {
      * @param idleTimeoutMs the idle timeout in milliseconds
      * @return Configuration Stage with value set.
      */
+    @CheckReturnValue
     ConfigurationStage withIdleTimeout(long idleTimeoutMs);
 
     /**
@@ -44,6 +47,7 @@ public interface ConfigurationStage {
      * @param maxLifetimeMs the maximum connection lifetime in milliseconds
      * @return Configuration Stage with value set.
      */
+    @CheckReturnValue
     ConfigurationStage withMaxLifetime(long maxLifetimeMs);
 
     /**
@@ -56,6 +60,7 @@ public interface ConfigurationStage {
      * @param maxPoolSize the maximum number of connections in the pool
      * @return Configuration Stage with value set.
      */
+    @CheckReturnValue
     ConfigurationStage withMaximumPoolSize(int maxPoolSize);
 
     /**
@@ -66,6 +71,7 @@ public interface ConfigurationStage {
      * @param minIdle the minimum number of idle connections in the pool to maintain
      * @return Configuration Stage with value set.
      */
+    @CheckReturnValue
     ConfigurationStage withMinimumIdle(int minIdle);
 
     /**
@@ -74,6 +80,7 @@ public interface ConfigurationStage {
      * @param password the password
      * @return Configuration Stage with value set.
      */
+    @CheckReturnValue
     ConfigurationStage usingPassword(String password);
 
     /**
@@ -82,6 +89,7 @@ public interface ConfigurationStage {
      * @param username the username
      * @return Configuration Stage with value set.
      */
+    @CheckReturnValue
     ConfigurationStage usingUsername(String username);
 
     /**
@@ -90,6 +98,7 @@ public interface ConfigurationStage {
      * @param className the fully qualified name of the JDBC {@link DataSource} class
      * @return Configuration Stage with value set.
      */
+    @CheckReturnValue
     ConfigurationStage withDataSourceClassName(Class<? extends DataSource> className);
 
     /**
@@ -98,6 +107,7 @@ public interface ConfigurationStage {
      * @param isAutoCommit the desired auto-commit default for connections
      * @return Configuration Stage with value set.
      */
+    @CheckReturnValue
     ConfigurationStage withAutoCommit(boolean isAutoCommit);
 
     /**
@@ -107,6 +117,7 @@ public interface ConfigurationStage {
      * @param keepaliveTimeMs the interval in which connections will be tested for aliveness, thus keeping them alive by the act of checking. Value is in milliseconds, default is 0 (disabled).
      * @return Configuration Stage with value set.
      */
+    @CheckReturnValue
     ConfigurationStage withKeepaliveTime(long keepaliveTimeMs);
 
     /**
@@ -116,6 +127,7 @@ public interface ConfigurationStage {
      * @param poolName the name of the connection pool to use
      * @return Configuration Stage with value set.
      */
+    @CheckReturnValue
     ConfigurationStage withPoolName(String poolName);
 
     /**
@@ -124,6 +136,7 @@ public interface ConfigurationStage {
      * @param executor the ScheduledExecutorService
      * @return Configuration Stage with value set.
      */
+    @CheckReturnValue
     ConfigurationStage withScheduledExecutor(ScheduledExecutorService executor);
 
     /**
@@ -132,6 +145,7 @@ public interface ConfigurationStage {
      * @param schema the name of the default schema
      * @return Configuration Stage with value set.
      */
+    @CheckReturnValue
     ConfigurationStage forSchema(String schema);
 
     /**
@@ -140,6 +154,7 @@ public interface ConfigurationStage {
      * @param threadFactory the thread factory (setting to null causes the default thread factory to be used)
      * @return Configuration Stage with value set.
      */
+    @CheckReturnValue
     ConfigurationStage withThreadFactory(ThreadFactory threadFactory);
 
     /**
@@ -147,5 +162,6 @@ public interface ConfigurationStage {
      *
      * @return hikari data source instance
      */
+    @CheckReturnValue
     HikariDataSource build();
 }

--- a/sadu-datasource/src/main/java/de/chojo/sadu/datasource/stage/JdbcStage.java
+++ b/sadu-datasource/src/main/java/de/chojo/sadu/datasource/stage/JdbcStage.java
@@ -6,6 +6,7 @@
 
 package de.chojo.sadu.datasource.stage;
 
+import javax.annotation.CheckReturnValue;
 import java.util.function.Consumer;
 
 /**
@@ -19,6 +20,7 @@ public interface JdbcStage<T> {
      * @param builder builder
      * @return builder isntance
      */
+    @CheckReturnValue
     JdbcStage<T> configure(Consumer<T> builder);
 
     /**

--- a/sadu-examples/build.gradle.kts
+++ b/sadu-examples/build.gradle.kts
@@ -3,7 +3,7 @@ dependencies {
 
     // database driver
     compileOnly("org.xerial", "sqlite-jdbc", "3.39.2.0")
-    compileOnly("org.postgresql", "postgresql", "42.4.2")
+    compileOnly("org.postgresql", "postgresql", "42.5.0")
     compileOnly("org.mariadb.jdbc", "mariadb-java-client", "3.0.7")
     compileOnly("mysql", "mysql-connector-java", "8.0.30")
 }

--- a/sadu-mapper/build.gradle.kts
+++ b/sadu-mapper/build.gradle.kts
@@ -1,5 +1,4 @@
 
 dependencies {
     api(project(":sadu-core"))
-    api(project(":sadu-mapper"))
 }

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/DefaultMapper.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/DefaultMapper.java
@@ -1,0 +1,117 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2022 RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.mapper;
+
+import de.chojo.sadu.exceptions.ThrowingBiFunction;
+import de.chojo.sadu.types.SqlType;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
+import de.chojo.sadu.mapper.util.Results;
+import de.chojo.sadu.wrapper.util.Row;
+
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public final class DefaultMapper {
+    private DefaultMapper() {
+        throw new UnsupportedOperationException("This is a utility class.");
+    }
+
+    public static RowMapper<Integer> createInteger(List<SqlType> types) {
+        return create(Integer.class, Row::getInt, types);
+    }
+
+    public static RowMapper<Long> createLong(List<SqlType> types) {
+        return create(Long.class, Row::getLong, types);
+    }
+
+    public static RowMapper<Float> createFloat(List<SqlType> types) {
+        return create(Float.class, Row::getFloat, types);
+    }
+
+    public static RowMapper<Double> createDouble(List<SqlType> types) {
+        return create(Double.class, Row::getDouble, types);
+    }
+
+    public static RowMapper<String> createString(List<SqlType> types) {
+        return create(String.class, Row::getString, types);
+    }
+
+    public static RowMapper<Boolean> createBoolean(List<SqlType> types) {
+        return create(Boolean.class, Row::getBoolean, types);
+    }
+
+    public static RowMapper<Byte[]> createBytes(List<SqlType> types) {
+        return create(Byte[].class, (row, columnIndex) -> convertByteArray(row.getBytes(columnIndex)), types);
+    }
+
+    public static RowMapper<UUID> createUuid(List<SqlType> textTypes, List<SqlType> byteTypes) {
+        return RowMapper.forClass(java.util.UUID.class)
+                        .mapper(row -> {
+                            ResultSetMetaData meta = row.getMetaData();
+                            Optional<Integer> columnIndexOfType = Results.getFirstColumnIndexOfType(meta, textTypes);
+                            if (columnIndexOfType.isPresent()) {
+                                return row.getUuidFromString(columnIndexOfType.get());
+                            }
+                            columnIndexOfType = Results.getFirstColumnIndexOfType(meta, byteTypes);
+                            Integer index = columnIndexOfType.orElseThrow(() -> {
+                                List<SqlType> sqlTypes = new ArrayList<>(textTypes);
+                                sqlTypes.addAll(byteTypes);
+                                return createException(sqlTypes, meta);
+                            });
+                            return row.getUuidFromBytes(index);
+                        })
+                        .build();
+    }
+
+    public static <T> RowMapper<T> create(Class<T> clazz, ThrowingBiFunction<Row, Integer, T, SQLException> mapper, List<SqlType> types) {
+        return RowMapper.forClass(clazz)
+                        .mapper(row -> {
+                            ResultSetMetaData meta = row.getMetaData();
+                            Optional<Integer> columnIndexOfType = Results.getFirstColumnIndexOfType(meta, types);
+                            Integer index = columnIndexOfType.orElseThrow(() -> createException(types, meta));
+                            return mapper.apply(row, index);
+                        }).build();
+    }
+
+    private static SQLException createException(List<SqlType> types, ResultSetMetaData meta) {
+        String type = types.stream().map(SqlType::descr)
+                              .collect(Collectors.joining(", "));
+        String available = "error";
+        try {
+            available = getColumnTypes(meta).entrySet().stream()
+                    .map(e -> "%s %s".formatted(e.getKey(), e.getValue()))
+                    .collect(Collectors.joining(", "));
+        } catch (SQLException e) {
+            // ignore
+        }
+        return new SQLException("No column of type %s present. Available: %s".formatted(type, available));
+    }
+
+    private static Map<String, String> getColumnTypes(ResultSetMetaData meta) throws SQLException {
+        Map<String, String> columns = new LinkedHashMap<>();
+        for (int i = 1; i <= meta.getColumnCount(); i++) {
+            columns.put(
+                    "%s | %s".formatted(i, meta.getColumnLabel(i)),
+                    "%s (%s)".formatted(meta.getColumnTypeName(i), meta.getColumnType(i)));
+        }
+        return columns;
+    }
+
+    private static Byte[] convertByteArray(byte[] primBytes) {
+        Byte[] bytes = new Byte[primBytes.length];
+        Arrays.setAll(bytes, n -> primBytes[n]);
+        return bytes;
+    }
+}

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/MapperConfig.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/MapperConfig.java
@@ -4,7 +4,7 @@
  *     Copyright (C) 2022 RainbowDashLabs and Contributor
  */
 
-package de.chojo.sadu.wrapper.mapper;
+package de.chojo.sadu.mapper;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/RowMapperRegistry.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/RowMapperRegistry.java
@@ -4,11 +4,12 @@
  *     Copyright (C) 2022 RainbowDashLabs and Contributor
  */
 
-package de.chojo.sadu.wrapper.mapper;
+package de.chojo.sadu.mapper;
 
-import de.chojo.sadu.wrapper.mapper.exceptions.MappingAlreadyRegisteredException;
-import de.chojo.sadu.wrapper.mapper.exceptions.MappingException;
-import de.chojo.sadu.wrapper.mapper.rowmapper.RowMapper;
+import de.chojo.sadu.mapper.exceptions.MappingAlreadyRegisteredException;
+import de.chojo.sadu.mapper.exceptions.MappingException;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
+import de.chojo.sadu.wrapper.util.Row;
 
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -56,6 +57,20 @@ public class RowMapperRegistry {
      * @throws MappingAlreadyRegisteredException when a mapping with the same column name exists already
      */
     public RowMapperRegistry register(RowMapper<?>... rowMapper) {
+        for (var mapper : rowMapper) {
+            register(mapper);
+        }
+        return this;
+    }
+    /**
+     * Registers new mapper.
+     * <p>
+     * A class can only have one mapper per column combination.
+     *
+     * @param rowMapper one or more mapper to register
+     * @throws MappingAlreadyRegisteredException when a mapping with the same column name exists already
+     */
+    public RowMapperRegistry register(List<RowMapper<?>> rowMapper) {
         for (var mapper : rowMapper) {
             register(mapper);
         }

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/exceptions/MappingAlreadyRegisteredException.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/exceptions/MappingAlreadyRegisteredException.java
@@ -4,7 +4,7 @@
  *     Copyright (C) 2022 RainbowDashLabs and Contributor
  */
 
-package de.chojo.sadu.wrapper.mapper.exceptions;
+package de.chojo.sadu.mapper.exceptions;
 
 public class MappingAlreadyRegisteredException extends RuntimeException {
     public MappingAlreadyRegisteredException(String message) {

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/exceptions/MappingException.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/exceptions/MappingException.java
@@ -4,9 +4,9 @@
  *     Copyright (C) 2022 RainbowDashLabs and Contributor
  */
 
-package de.chojo.sadu.wrapper.mapper.exceptions;
+package de.chojo.sadu.mapper.exceptions;
 
-import de.chojo.sadu.wrapper.mapper.util.Results;
+import de.chojo.sadu.mapper.util.Results;
 
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/rowmapper/PartialRowMapper.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/rowmapper/PartialRowMapper.java
@@ -4,7 +4,7 @@
  *     Copyright (C) 2022 RainbowDashLabs and Contributor
  */
 
-package de.chojo.sadu.wrapper.mapper.rowmapper;
+package de.chojo.sadu.mapper.rowmapper;
 
 import de.chojo.sadu.exceptions.ThrowingFunction;
 import de.chojo.sadu.wrapper.util.Row;

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/rowmapper/RowMapper.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/rowmapper/RowMapper.java
@@ -4,12 +4,13 @@
  *     Copyright (C) 2022 RainbowDashLabs and Contributor
  */
 
-package de.chojo.sadu.wrapper.mapper.rowmapper;
+package de.chojo.sadu.mapper.rowmapper;
 
 import de.chojo.sadu.exceptions.ThrowingFunction;
-import de.chojo.sadu.wrapper.mapper.MapperConfig;
+import de.chojo.sadu.mapper.MapperConfig;
 import de.chojo.sadu.wrapper.util.Row;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -17,7 +18,7 @@ import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.Set;
 
-import static de.chojo.sadu.wrapper.mapper.util.Results.columnNames;
+import static de.chojo.sadu.mapper.util.Results.columnNames;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -26,7 +27,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  * @param <T> type of retuned object
  */
 public class RowMapper<T> {
-    private static final Logger log = getLogger(RowMapper.class);
+    private static final Logger log = LoggerFactory.getLogger(RowMapper.class);
     private final Class<T> clazz;
     private final ThrowingFunction<? extends T, Row, SQLException> mapper;
     private final Set<String> columns;

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/rowmapper/RowMapperBuilder.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/rowmapper/RowMapperBuilder.java
@@ -4,7 +4,7 @@
  *     Copyright (C) 2022 RainbowDashLabs and Contributor
  */
 
-package de.chojo.sadu.wrapper.mapper.rowmapper;
+package de.chojo.sadu.mapper.rowmapper;
 
 import de.chojo.sadu.exceptions.ThrowingFunction;
 import de.chojo.sadu.wrapper.util.Row;

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/util/Results.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/util/Results.java
@@ -4,12 +4,16 @@
  *     Copyright (C) 2022 RainbowDashLabs and Contributor
  */
 
-package de.chojo.sadu.wrapper.mapper.util;
+package de.chojo.sadu.mapper.util;
+
+import de.chojo.sadu.types.SqlType;
 
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public final class Results {
@@ -37,9 +41,30 @@ public final class Results {
      */
     public static Set<String> columnNames(ResultSetMetaData meta) throws SQLException {
         Set<String> columns = new HashSet<>();
-        for (int i = 1; i <= meta.getColumnCount(); i++) {
+        for (var i = 1; i <= meta.getColumnCount(); i++) {
             columns.add(meta.getColumnLabel(i));
         }
         return columns;
+    }
+
+    /**
+     * Extracts the column index (1 based) of the first column with the requested type.
+     *
+     * @param meta  meta of the result set
+     * @param types a list of valid types where the index will be returned
+     * @return the index of the column with the first type contained in types
+     * @throws SQLException if a database access error occurs
+     */
+    public static Optional<Integer> getFirstColumnIndexOfType(ResultSetMetaData meta, List<SqlType> types) throws SQLException {
+        for (var i = 1; i <= meta.getColumnCount(); i++) {
+            var typeName = meta.getColumnTypeName(i);
+            for (var type : types) {
+                if (typeName.equalsIgnoreCase(type.name())) return Optional.of(i);
+                for (var alias : type.alias()) {
+                    if (typeName.equalsIgnoreCase(alias)) return Optional.of(i);
+                }
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/sadu-mapper/src/main/java/de/chojo/sadu/wrapper/util/Row.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/wrapper/util/Row.java
@@ -9,7 +9,7 @@ package de.chojo.sadu.wrapper.util;
 import de.chojo.sadu.conversion.ArrayConverter;
 import de.chojo.sadu.conversion.UUIDConverter;
 import de.chojo.sadu.mapper.MapperConfig;
-
+import org.jetbrains.annotations.ApiStatus;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -34,7 +34,7 @@ import java.util.Map;
 import java.util.UUID;
 
 /**
- * Represents the row of an result set. Made to restrict actions on valid calls.
+ * Represents the row of a result set. Made to restrict actions on valid calls.
  */
 @SuppressWarnings("unused")
 public class Row {
@@ -53,10 +53,13 @@ public class Row {
     }
 
     /**
-     * Get the underlying result set
+     * Get the underlying result set.
+     * <p>
+     * <b>This result set should never be modified by moving the cursor</b>
      *
      * @return resultSet
      */
+    @ApiStatus.Internal
     public ResultSet resultSet() {
         return resultSet;
     }
@@ -75,6 +78,32 @@ public class Row {
      */
     public String getString(int columnIndex) throws SQLException {
         return resultSet.getString(columnIndex);
+    }
+
+    /**
+     * Retrieves the value of the designated column in the current row
+     * of this {@code Row} object as
+     * a {@code String} in the Java programming language and maps it to an enum.
+     *
+     * @param columnIndex the first column is 1, the second is 2, ...
+     * @param clazz       the enum clazz
+     * @param <T>         type of enum
+     * @return the column value; if the value is SQL {@code NULL}, the
+     * value returned is {@code null}
+     * @throws SQLException             if the columnIndex is not valid;
+     *                                  if a database access error occurs or this method is
+     *                                  called on a closed result set
+     * @throws IllegalArgumentException when the value could not be mapped
+     * @throws NullPointerException     when the class is null
+     *
+     * @since 1.2
+     */
+    public <T extends Enum<T>> T getEnum(int columnIndex, Class<T> clazz) throws SQLException {
+        var value = getString(columnIndex);
+        if (value == null) {
+            return null;
+        }
+        return Enum.valueOf(clazz, value);
     }
 
     /**
@@ -365,6 +394,31 @@ public class Row {
      */
     public String getString(String columnLabel) throws SQLException {
         return resultSet.getString(columnAlias(columnLabel));
+    }
+
+    /**
+     * Retrieves the value of the designated column in the current row
+     * of this {@code Row} object as
+     * a {@code String} in the Java programming language and maps it to an enum.
+     *
+     * @param columnLabel the label for the column specified with the SQL AS clause.  If the SQL AS clause was not specified, then the label is the name of the column
+     * @param clazz       the enum clazz
+     * @param <T>         type of enum
+     * @return the column value; if the value is SQL {@code NULL}, the
+     * value returned is {@code null}
+     * @throws SQLException             if the columnIndex is not valid;
+     *                                  if a database access error occurs or this method is
+     *                                  called on a closed result set
+     * @throws IllegalArgumentException when the value could not be mapped
+     * @throws NullPointerException     when the class is null
+     * @since 1.2
+     */
+    public <T extends Enum<T>> T getEnum(String columnLabel, Class<T> clazz) throws SQLException {
+        var value = getString(columnLabel);
+        if (value == null) {
+            return null;
+        }
+        return Enum.valueOf(clazz, value);
     }
 
     /**
@@ -770,7 +824,7 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
-     * @since 1.2
+
      */
     public Reader getCharacterStream(int columnIndex) throws SQLException {
         return resultSet.getCharacterStream(columnIndex);
@@ -788,7 +842,7 @@ public class Row {
      * @throws SQLException if the columnLabel is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
-     * @since 1.2
+
      */
     public Reader getCharacterStream(String columnLabel) throws SQLException {
         return resultSet.getCharacterStream(columnAlias(columnLabel));
@@ -806,7 +860,7 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
-     * @since 1.2
+
      */
     public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
         return resultSet.getBigDecimal(columnIndex);
@@ -824,7 +878,7 @@ public class Row {
      * @throws SQLException if the columnLabel is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
-     * @since 1.2
+
      */
     public BigDecimal getBigDecimal(String columnLabel) throws SQLException {
         return resultSet.getBigDecimal(columnAlias(columnLabel));
@@ -850,7 +904,7 @@ public class Row {
      *                                         or this method is called on a closed result set
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.2
+
      */
     public Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException {
         return resultSet.getObject(columnIndex, map);
@@ -869,7 +923,7 @@ public class Row {
      *                                         or this method is called on a closed result set
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.2
+
      */
     public Ref getRef(int columnIndex) throws SQLException {
         return resultSet.getRef(columnIndex);
@@ -888,7 +942,7 @@ public class Row {
      *                                         or this method is called on a closed result set
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.2
+
      */
     public Blob getBlob(int columnIndex) throws SQLException {
         return resultSet.getBlob(columnIndex);
@@ -907,7 +961,7 @@ public class Row {
      *                                         or this method is called on a closed result set
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.2
+
      */
     public Clob getClob(int columnIndex) throws SQLException {
         return resultSet.getClob(columnIndex);
@@ -926,7 +980,7 @@ public class Row {
      *                                         or this method is called on a closed result set
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.2
+
      */
     public Array getArray(int columnIndex) throws SQLException {
         return resultSet.getArray(columnIndex);
@@ -951,7 +1005,7 @@ public class Row {
      *                                         or this method is called on a closed result set
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.2
+
      */
     public Object getObject(String columnLabel, Map<String, Class<?>> map) throws SQLException {
         return resultSet.getObject(columnAlias(columnLabel), map);
@@ -970,7 +1024,7 @@ public class Row {
      *                                         or this method is called on a closed result set
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.2
+
      */
     public Ref getRef(String columnLabel) throws SQLException {
         return resultSet.getRef(columnAlias(columnLabel));
@@ -989,7 +1043,7 @@ public class Row {
      *                                         or this method is called on a closed result set
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.2
+
      */
     public Blob getBlob(String columnLabel) throws SQLException {
         return resultSet.getBlob(columnAlias(columnLabel));
@@ -1008,7 +1062,7 @@ public class Row {
      *                                         or this method is called on a closed result set
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.2
+
      */
     public Clob getClob(String columnLabel) throws SQLException {
         return resultSet.getClob(columnAlias(columnLabel));
@@ -1027,7 +1081,7 @@ public class Row {
      *                                         or this method is called on a closed result set
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.2
+
      */
     public Array getArray(String columnLabel) throws SQLException {
         return resultSet.getArray(columnAlias(columnLabel));
@@ -1050,7 +1104,7 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs
      *                      or this method is called on a closed result set
-     * @since 1.2
+
      */
     public Date getDate(int columnIndex, Calendar cal) throws SQLException {
         return resultSet.getDate(columnIndex, cal);
@@ -1073,7 +1127,7 @@ public class Row {
      * @throws SQLException if the columnLabel is not valid;
      *                      if a database access error occurs
      *                      or this method is called on a closed result set
-     * @since 1.2
+
      */
     public Date getDate(String columnLabel, Calendar cal) throws SQLException {
         return resultSet.getDate(columnAlias(columnLabel), cal);
@@ -1096,7 +1150,7 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs
      *                      or this method is called on a closed result set
-     * @since 1.2
+
      */
     public Time getTime(int columnIndex, Calendar cal) throws SQLException {
         return resultSet.getTime(columnIndex, cal);
@@ -1119,7 +1173,7 @@ public class Row {
      * @throws SQLException if the columnLabel is not valid;
      *                      if a database access error occurs
      *                      or this method is called on a closed result set
-     * @since 1.2
+
      */
     public Time getTime(String columnLabel, Calendar cal) throws SQLException {
         return resultSet.getTime(columnAlias(columnLabel), cal);
@@ -1142,7 +1196,7 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs
      *                      or this method is called on a closed result set
-     * @since 1.2
+
      */
     public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
         return resultSet.getTimestamp(columnIndex, cal);
@@ -1165,7 +1219,7 @@ public class Row {
      * @throws SQLException if the columnLabel is not valid or
      *                      if a database access error occurs
      *                      or this method is called on a closed result set
-     * @since 1.2
+
      */
     public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
         return resultSet.getTimestamp(columnAlias(columnLabel), cal);
@@ -1185,7 +1239,7 @@ public class Row {
      *                                         is called on a closed result set or if a URL is malformed
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.4
+
      */
     public URL getURL(int columnIndex) throws SQLException {
         return resultSet.getURL(columnIndex);
@@ -1205,7 +1259,7 @@ public class Row {
      *                                         is called on a closed result set or if a URL is malformed
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.4
+
      */
     public URL getURL(String columnLabel) throws SQLException {
         return resultSet.getURL(columnAlias(columnLabel));
@@ -1224,7 +1278,7 @@ public class Row {
      *                                         or this method is called on a closed result set
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.6
+
      */
     public RowId getRowId(int columnIndex) throws SQLException {
         return resultSet.getRowId(columnIndex);
@@ -1243,7 +1297,7 @@ public class Row {
      *                                         or this method is called on a closed result set
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.6
+
      */
     public RowId getRowId(String columnLabel) throws SQLException {
         return resultSet.getRowId(columnAlias(columnLabel));
@@ -1264,7 +1318,7 @@ public class Row {
      *                                         or if a database access error occurs
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.6
+
      */
     public NClob getNClob(int columnIndex) throws SQLException {
         return resultSet.getNClob(columnIndex);
@@ -1285,7 +1339,7 @@ public class Row {
      *                                         or if a database access error occurs
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.6
+
      */
     public NClob getNClob(String columnLabel) throws SQLException {
         return resultSet.getNClob(columnAlias(columnLabel));
@@ -1303,7 +1357,7 @@ public class Row {
      *                                         or this method is called on a closed result set
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.6
+
      */
     public SQLXML getSQLXML(int columnIndex) throws SQLException {
         return resultSet.getSQLXML(columnIndex);
@@ -1321,7 +1375,7 @@ public class Row {
      *                                         or this method is called on a closed result set
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.6
+
      */
     public SQLXML getSQLXML(String columnLabel) throws SQLException {
         return resultSet.getSQLXML(columnAlias(columnLabel));
@@ -1343,7 +1397,7 @@ public class Row {
      *                                         or this method is called on a closed result set
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.6
+
      */
     public String getNString(int columnIndex) throws SQLException {
         return resultSet.getNString(columnIndex);
@@ -1365,7 +1419,7 @@ public class Row {
      *                                         or this method is called on a closed result set
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.6
+
      */
     public String getNString(String columnLabel) throws SQLException {
         return resultSet.getNString(columnAlias(columnLabel));
@@ -1388,7 +1442,7 @@ public class Row {
      *                                         or this method is called on a closed result set
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.6
+
      */
     public Reader getNCharacterStream(int columnIndex) throws SQLException {
         return resultSet.getNCharacterStream(columnIndex);
@@ -1411,7 +1465,7 @@ public class Row {
      *                                         or this method is called on a closed result set
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.6
+
      */
     public Reader getNCharacterStream(String columnLabel) throws SQLException {
         return resultSet.getNCharacterStream(columnAlias(columnLabel));
@@ -1441,7 +1495,7 @@ public class Row {
      *                                         a conversion error occurs
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.7
+
      */
     public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
         return resultSet.getObject(columnIndex, type);
@@ -1473,7 +1527,7 @@ public class Row {
      *                                         a conversion error occurs
      * @throws SQLFeatureNotSupportedException if the JDBC driver does not support
      *                                         this method
-     * @since 1.7
+
      */
     public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
         return resultSet.getObject(columnAlias(columnLabel), type);

--- a/sadu-mapper/src/main/java/de/chojo/sadu/wrapper/util/Row.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/wrapper/util/Row.java
@@ -8,7 +8,7 @@ package de.chojo.sadu.wrapper.util;
 
 import de.chojo.sadu.conversion.ArrayConverter;
 import de.chojo.sadu.conversion.UUIDConverter;
-import de.chojo.sadu.wrapper.mapper.MapperConfig;
+import de.chojo.sadu.mapper.MapperConfig;
 
 import java.io.InputStream;
 import java.io.Reader;

--- a/sadu-mariadb/build.gradle.kts
+++ b/sadu-mariadb/build.gradle.kts
@@ -1,3 +1,7 @@
 dependencies {
     api(project(":sadu-core"))
+    api(project(":sadu-mapper"))
+
+    testImplementation("org.mariadb.jdbc:mariadb-java-client:3.0.7")
+    testImplementation(project(":sadu-queries"))
 }

--- a/sadu-mariadb/src/main/java/de/chojo/sadu/jdbc/MariaDbJdbc.java
+++ b/sadu-mariadb/src/main/java/de/chojo/sadu/jdbc/MariaDbJdbc.java
@@ -6,6 +6,8 @@
 
 package de.chojo.sadu.jdbc;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * Represents a builder to create a MariaDB jdbc url.
  */
@@ -16,7 +18,7 @@ public class MariaDbJdbc extends RemoteJdbcConfig<MariaDbJdbc> {
     }
 
     /**
-     * The connect timeout value, in milliseconds, or zero for no timeout.
+     * The connection timeout value, in milliseconds, or zero for no timeout.
      * Default: 30 000.
      *
      * @param millis milliseconds

--- a/sadu-mariadb/src/main/java/de/chojo/sadu/mapper/MariaDbMapper.java
+++ b/sadu-mariadb/src/main/java/de/chojo/sadu/mapper/MariaDbMapper.java
@@ -1,0 +1,60 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2022 RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.mapper;
+
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
+
+import java.util.List;
+import java.util.UUID;
+
+import static de.chojo.sadu.mapper.DefaultMapper.createBoolean;
+import static de.chojo.sadu.mapper.DefaultMapper.createBytes;
+import static de.chojo.sadu.mapper.DefaultMapper.createDouble;
+import static de.chojo.sadu.mapper.DefaultMapper.createFloat;
+import static de.chojo.sadu.mapper.DefaultMapper.createInteger;
+import static de.chojo.sadu.mapper.DefaultMapper.createLong;
+import static de.chojo.sadu.mapper.DefaultMapper.createString;
+import static de.chojo.sadu.mapper.DefaultMapper.createUuid;
+import static de.chojo.sadu.types.MariaDbTypes.BIGINT;
+import static de.chojo.sadu.types.MariaDbTypes.BLOB;
+import static de.chojo.sadu.types.MariaDbTypes.BOOLEAN;
+import static de.chojo.sadu.types.MariaDbTypes.DECIMAL;
+import static de.chojo.sadu.types.MariaDbTypes.DOUBLE;
+import static de.chojo.sadu.types.MariaDbTypes.FLOAT;
+import static de.chojo.sadu.types.MariaDbTypes.INT;
+import static de.chojo.sadu.types.MariaDbTypes.LONGBLOB;
+import static de.chojo.sadu.types.MariaDbTypes.LONGTEXT;
+import static de.chojo.sadu.types.MariaDbTypes.MEDIUMBLOB;
+import static de.chojo.sadu.types.MariaDbTypes.MEDIUMINT;
+import static de.chojo.sadu.types.MariaDbTypes.MEDIUMTEXT;
+import static de.chojo.sadu.types.MariaDbTypes.SMALLINT;
+import static de.chojo.sadu.types.MariaDbTypes.TEXT;
+import static de.chojo.sadu.types.MariaDbTypes.TINYBLOB;
+import static de.chojo.sadu.types.MariaDbTypes.TINYINT;
+import static de.chojo.sadu.types.MariaDbTypes.TINYTEXT;
+import static de.chojo.sadu.types.MariaDbTypes.VARBINARY;
+import static de.chojo.sadu.types.MariaDbTypes.VARCHAR;
+
+public final class MariaDbMapper {
+    private MariaDbMapper() {
+        throw new UnsupportedOperationException("This is a utility class.");
+    }
+
+    public static final RowMapper<Boolean> BOOLEAN_MAPPER = createBoolean(List.of(BOOLEAN));
+    public static final RowMapper<Integer> INTEGER_MAPPER = createInteger(List.of(TINYINT, SMALLINT, MEDIUMINT, INT));
+    public static final RowMapper<Long> LONG_MAPPER = createLong(List.of(BIGINT, TINYINT, SMALLINT, MEDIUMINT, INT));
+    public static final RowMapper<Float> FLOAT_MAPPER = createFloat(List.of(DOUBLE, DECIMAL, FLOAT));
+    public static final RowMapper<Double> DOUBLE_MAPPER = createDouble(List.of(DOUBLE, DECIMAL, FLOAT));
+    public static final RowMapper<String> STRING_MAPPER = createString(List.of(TINYTEXT, TEXT, MEDIUMTEXT, LONGTEXT, VARCHAR));
+    public static final RowMapper<Byte[]> BYTES_MAPPER = createBytes(List.of(TINYTEXT, TEXT, MEDIUMTEXT, LONGTEXT, VARCHAR));
+    public static final RowMapper<UUID> UUID_MAPPER = createUuid(List.of(TINYTEXT, TEXT, MEDIUMTEXT, LONGTEXT, VARCHAR),
+            List.of(TINYBLOB, BLOB, MEDIUMBLOB, LONGBLOB, VARBINARY));
+
+    public static List<RowMapper<?>> getDefaultMapper(){
+        return List.of(BOOLEAN_MAPPER, INTEGER_MAPPER, LONG_MAPPER, FLOAT_MAPPER, DOUBLE_MAPPER, STRING_MAPPER, BYTES_MAPPER, UUID_MAPPER);
+    }
+}

--- a/sadu-mariadb/src/main/java/de/chojo/sadu/types/MariaDbTypes.java
+++ b/sadu-mariadb/src/main/java/de/chojo/sadu/types/MariaDbTypes.java
@@ -54,7 +54,7 @@ public interface MariaDbTypes {
     /**
      * -2,147,483,648 and 2,147,483,647
      */
-    SqlType INT = ofName("INT");
+    SqlType INT = ofName("INT", "INTEGER");
     /**
      * "Unlimited"
      */
@@ -76,7 +76,7 @@ public interface MariaDbTypes {
     /**
      * Boolean representation
      */
-    SqlType BOOLEAN = ofName("BOOLEAN");
+    SqlType BOOLEAN = ofName("BOOLEAN", "INTEGER");
 
     /**
      * Fixed {@literal <} 255 with padding

--- a/sadu-mariadb/src/test/java/de/chojo/sadu/jdbc/MariaDbJdbcTest.java
+++ b/sadu-mariadb/src/test/java/de/chojo/sadu/jdbc/MariaDbJdbcTest.java
@@ -7,6 +7,9 @@
 package de.chojo.sadu.jdbc;
 
 import de.chojo.sadu.databases.MariaDb;
+import de.chojo.sadu.mapper.MariaDbMapper;
+import de.chojo.sadu.mapper.RowMapperRegistry;
+import de.chojo.sadu.wrapper.QueryBuilderConfig;
 import org.junit.jupiter.api.BeforeEach;
 
 class MariaDbJdbcTest {

--- a/sadu-mariadb/src/test/java/de/chojo/sadu/mapper/MariaDbMapperTest.java
+++ b/sadu-mariadb/src/test/java/de/chojo/sadu/mapper/MariaDbMapperTest.java
@@ -1,0 +1,52 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2022 RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.mapper;
+
+import de.chojo.sadu.base.QueryFactory;
+import de.chojo.sadu.databases.MariaDb;
+import de.chojo.sadu.wrapper.QueryBuilder;
+import de.chojo.sadu.wrapper.QueryBuilderConfig;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.mariadb.jdbc.MariaDbDataSource;
+
+import java.sql.SQLException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MariaDbMapperTest {
+
+    @Test
+    @Disabled
+    public void test() throws SQLException {
+        MariaDbDataSource dataSource = new MariaDbDataSource(MariaDb.get().jdbcBuilder().login("root", "root").jdbcUrl());
+
+        RowMapperRegistry registry = new RowMapperRegistry().register(MariaDbMapper.getDefaultMapper());
+
+        QueryBuilderConfig.setDefault(QueryBuilderConfig.builder().rowMappers(registry).build());
+
+        QueryFactory queryFactory = new QueryFactory(dataSource);
+
+        Optional<Integer> integer = queryFactory.builder(Integer.class)
+                .query("SELECT 1")
+                .emptyParams()
+                .map()
+                .firstSync();
+
+        assertTrue(integer.isPresent());
+
+        Optional<Boolean> bool = queryFactory.builder(Boolean.class)
+                .query("SELECT TRUE")
+                .emptyParams()
+                .map()
+                .firstSync();
+
+        assertTrue(bool.isPresent());
+    }
+
+}

--- a/sadu-mysql/build.gradle.kts
+++ b/sadu-mysql/build.gradle.kts
@@ -1,3 +1,4 @@
 dependencies {
     api(project(":sadu-core"))
+    api(project(":sadu-mapper"))
 }

--- a/sadu-mysql/src/main/java/de/chojo/sadu/mapper/MySqlMapper.java
+++ b/sadu-mysql/src/main/java/de/chojo/sadu/mapper/MySqlMapper.java
@@ -1,0 +1,60 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2022 RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.mapper;
+
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
+
+import java.util.List;
+import java.util.UUID;
+
+import static de.chojo.sadu.mapper.DefaultMapper.createBoolean;
+import static de.chojo.sadu.mapper.DefaultMapper.createBytes;
+import static de.chojo.sadu.mapper.DefaultMapper.createDouble;
+import static de.chojo.sadu.mapper.DefaultMapper.createFloat;
+import static de.chojo.sadu.mapper.DefaultMapper.createInteger;
+import static de.chojo.sadu.mapper.DefaultMapper.createLong;
+import static de.chojo.sadu.mapper.DefaultMapper.createString;
+import static de.chojo.sadu.mapper.DefaultMapper.createUuid;
+import static de.chojo.sadu.types.MySqlTypes.BIGINT;
+import static de.chojo.sadu.types.MySqlTypes.BLOB;
+import static de.chojo.sadu.types.MySqlTypes.BOOLEAN;
+import static de.chojo.sadu.types.MySqlTypes.DECIMAL;
+import static de.chojo.sadu.types.MySqlTypes.DOUBLE;
+import static de.chojo.sadu.types.MySqlTypes.FLOAT;
+import static de.chojo.sadu.types.MySqlTypes.INT;
+import static de.chojo.sadu.types.MySqlTypes.LONGBLOB;
+import static de.chojo.sadu.types.MySqlTypes.LONGTEXT;
+import static de.chojo.sadu.types.MySqlTypes.MEDIUMBLOB;
+import static de.chojo.sadu.types.MySqlTypes.MEDIUMINT;
+import static de.chojo.sadu.types.MySqlTypes.MEDIUMTEXT;
+import static de.chojo.sadu.types.MySqlTypes.SMALLINT;
+import static de.chojo.sadu.types.MySqlTypes.TEXT;
+import static de.chojo.sadu.types.MySqlTypes.TINYBLOB;
+import static de.chojo.sadu.types.MySqlTypes.TINYINT;
+import static de.chojo.sadu.types.MySqlTypes.TINYTEXT;
+import static de.chojo.sadu.types.MySqlTypes.VARBINARY;
+import static de.chojo.sadu.types.MySqlTypes.VARCHAR;
+
+public final class MySqlMapper {
+    private MySqlMapper() {
+        throw new UnsupportedOperationException("This is a utility class.");
+    }
+
+    public static final RowMapper<Boolean> BOOLEAN_MAPPER = createBoolean(List.of(BOOLEAN));
+    public static final RowMapper<Integer> INTEGER_MAPPER = createInteger(List.of(TINYINT, SMALLINT, MEDIUMINT, INT));
+    public static final RowMapper<Long> LONG_MAPPER = createLong(List.of(BIGINT, TINYINT, SMALLINT, MEDIUMINT, INT));
+    public static final RowMapper<Float> FLOAT_MAPPER = createFloat(List.of(DOUBLE, DECIMAL, FLOAT));
+    public static final RowMapper<Double> DOUBLE_MAPPER = createDouble(List.of(DOUBLE, DECIMAL, FLOAT));
+    public static final RowMapper<String> STRING_MAPPER = createString(List.of(TINYTEXT, TEXT, MEDIUMTEXT, LONGTEXT, VARCHAR));
+    public static final RowMapper<Byte[]> BYTES_MAPPER = createBytes(List.of(TINYTEXT, TEXT, MEDIUMTEXT, LONGTEXT, VARCHAR));
+    public static final RowMapper<UUID> UUID_MAPPER = createUuid(List.of(TINYTEXT, TEXT, MEDIUMTEXT, LONGTEXT, VARCHAR),
+            List.of(TINYBLOB, BLOB, MEDIUMBLOB, LONGBLOB, VARBINARY));
+
+    public static List<RowMapper<?>> getDefaultMapper(){
+        return List.of(BOOLEAN_MAPPER, INTEGER_MAPPER, LONG_MAPPER, FLOAT_MAPPER, DOUBLE_MAPPER, STRING_MAPPER, BYTES_MAPPER, UUID_MAPPER);
+    }
+}

--- a/sadu-mysql/src/main/java/de/chojo/sadu/types/MySqlTypes.java
+++ b/sadu-mysql/src/main/java/de/chojo/sadu/types/MySqlTypes.java
@@ -54,7 +54,7 @@ public interface MySqlTypes {
     /**
      * -2,147,483,648 and 2,147,483,647
      */
-    SqlType INT = ofName("INT");
+    SqlType INT = ofName("INT", "INTEGER");
     /**
      * "Unlimited"
      */
@@ -76,7 +76,7 @@ public interface MySqlTypes {
     /**
      * Boolean representation
      */
-    SqlType BOOLEAN = ofName("BOOLEAN");
+    SqlType BOOLEAN = ofName("BOOLEAN", "INTEGER");
 
     /**
      * Fixed {@literal <} 255 with padding

--- a/sadu-postgresql/build.gradle.kts
+++ b/sadu-postgresql/build.gradle.kts
@@ -1,3 +1,4 @@
 dependencies {
     api(project(":sadu-core"))
+    api(project(":sadu-mapper"))
 }

--- a/sadu-postgresql/src/main/java/de/chojo/sadu/mapper/PostgresqlMapper.java
+++ b/sadu-postgresql/src/main/java/de/chojo/sadu/mapper/PostgresqlMapper.java
@@ -1,0 +1,51 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2022 RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.mapper;
+
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
+
+import java.util.List;
+import java.util.UUID;
+
+import static de.chojo.sadu.mapper.DefaultMapper.createBoolean;
+import static de.chojo.sadu.mapper.DefaultMapper.createBytes;
+import static de.chojo.sadu.mapper.DefaultMapper.createDouble;
+import static de.chojo.sadu.mapper.DefaultMapper.createFloat;
+import static de.chojo.sadu.mapper.DefaultMapper.createInteger;
+import static de.chojo.sadu.mapper.DefaultMapper.createLong;
+import static de.chojo.sadu.mapper.DefaultMapper.createString;
+import static de.chojo.sadu.mapper.DefaultMapper.createUuid;
+import static de.chojo.sadu.types.PostgreSqlTypes.BIGINT;
+import static de.chojo.sadu.types.PostgreSqlTypes.BOOLEAN;
+import static de.chojo.sadu.types.PostgreSqlTypes.BYTEA;
+import static de.chojo.sadu.types.PostgreSqlTypes.CHAR;
+import static de.chojo.sadu.types.PostgreSqlTypes.DECIMAL;
+import static de.chojo.sadu.types.PostgreSqlTypes.DOUBLE;
+import static de.chojo.sadu.types.PostgreSqlTypes.INTEGER;
+import static de.chojo.sadu.types.PostgreSqlTypes.NUMERIC;
+import static de.chojo.sadu.types.PostgreSqlTypes.SMALLINT;
+import static de.chojo.sadu.types.PostgreSqlTypes.TEXT;
+import static de.chojo.sadu.types.PostgreSqlTypes.VARCHAR;
+
+public final class PostgresqlMapper {
+    private PostgresqlMapper() {
+        throw new UnsupportedOperationException("This is a utility class.");
+    }
+
+    public static final RowMapper<Boolean> BOOLEAN_MAPPER = createBoolean(List.of(BOOLEAN));
+    public static final RowMapper<Integer> INTEGER_MAPPER = createInteger(List.of(SMALLINT, INTEGER));
+    public static final RowMapper<Long> LONG_MAPPER = createLong(List.of(SMALLINT, INTEGER, BIGINT));
+    public static final RowMapper<Float> FLOAT_MAPPER = createFloat(List.of(DECIMAL, NUMERIC, DOUBLE));
+    public static final RowMapper<Double> DOUBLE_MAPPER = createDouble(List.of(DECIMAL, NUMERIC, DOUBLE));
+    public static final RowMapper<String> STRING_MAPPER = createString(List.of(TEXT, VARCHAR, CHAR));
+    public static final RowMapper<Byte[]> BYTES_MAPPER = createBytes(List.of(BYTEA));
+    public static final RowMapper<UUID> UUID_MAPPER = createUuid(List.of(TEXT), List.of(BYTEA));
+
+    public static List<RowMapper<?>> getDefaultMapper() {
+        return List.of(BOOLEAN_MAPPER, INTEGER_MAPPER, LONG_MAPPER, FLOAT_MAPPER, DOUBLE_MAPPER, STRING_MAPPER, BYTES_MAPPER, UUID_MAPPER);
+    }
+}

--- a/sadu-queries/build.gradle.kts
+++ b/sadu-queries/build.gradle.kts
@@ -1,8 +1,10 @@
 
 dependencies {
     api(project(":sadu-core"))
+    api(project(":sadu-mapper"))
 
     testImplementation(project(":sadu-datasource"))
     testImplementation(project(":sadu-sqlite"))
+    testImplementation(project(":sadu-mapper"))
     testImplementation("org.xerial", "sqlite-jdbc", "3.39.2.0")
 }

--- a/sadu-queries/src/main/java/de/chojo/sadu/wrapper/QueryBuilder.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/wrapper/QueryBuilder.java
@@ -9,10 +9,10 @@ package de.chojo.sadu.wrapper;
 import de.chojo.sadu.base.DataHolder;
 import de.chojo.sadu.exceptions.ThrowingConsumer;
 import de.chojo.sadu.exceptions.ThrowingFunction;
+import de.chojo.sadu.mapper.MapperConfig;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.wrapper.exception.QueryExecutionException;
 import de.chojo.sadu.wrapper.exception.WrappedQueryExecutionException;
-import de.chojo.sadu.wrapper.mapper.MapperConfig;
-import de.chojo.sadu.wrapper.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.wrapper.stage.ConfigurationStage;
 import de.chojo.sadu.wrapper.stage.InsertStage;
 import de.chojo.sadu.wrapper.stage.QueryStage;
@@ -167,6 +167,7 @@ public class QueryBuilder<T> extends DataHolder implements ConfigurationStage<T>
     public RetrievalStage<T> map(MapperConfig mapperConfig) {
         Objects.requireNonNull(clazz);
         this.mapperConfig = mapperConfig.clone();
+        queueTask();
         return this;
     }
 

--- a/sadu-queries/src/main/java/de/chojo/sadu/wrapper/QueryBuilder.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/wrapper/QueryBuilder.java
@@ -347,7 +347,7 @@ public class QueryBuilder<T> extends DataHolder implements ConfigurationStage<T>
 
     /*
     Execute all queries, since we are only interested in the result of the last of our queries.
-    Thats why we will execute all queries inside this method regardless of the method which calls this method
+    That's why we will execute all queries inside this method regardless of the method which calls this method
     We will use a single connection for this, since the user may be interested in the last inserted id or something.
     */
     private QueryTask executeAndGetLast(Connection conn) throws QueryExecutionException {

--- a/sadu-queries/src/main/java/de/chojo/sadu/wrapper/QueryBuilderConfig.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/wrapper/QueryBuilderConfig.java
@@ -8,9 +8,9 @@ package de.chojo.sadu.wrapper;
 
 import de.chojo.sadu.base.QueryFactory;
 import de.chojo.sadu.exceptions.ExceptionTransformer;
+import de.chojo.sadu.mapper.RowMapperRegistry;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.wrapper.exception.QueryExecutionException;
-import de.chojo.sadu.wrapper.mapper.RowMapperRegistry;
-import de.chojo.sadu.wrapper.mapper.rowmapper.RowMapper;
 import org.jetbrains.annotations.NotNull;
 
 import java.sql.SQLException;

--- a/sadu-queries/src/main/java/de/chojo/sadu/wrapper/stage/ConfigurationStage.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/wrapper/stage/ConfigurationStage.java
@@ -10,6 +10,7 @@ import de.chojo.sadu.base.QueryFactory;
 import de.chojo.sadu.wrapper.QueryBuilder;
 import de.chojo.sadu.wrapper.QueryBuilderConfig;
 
+import javax.annotation.CheckReturnValue;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -27,6 +28,7 @@ public interface ConfigurationStage<T> {
      * @param config The config of the {@link QueryBuilder}
      * @return The {@link QueryBuilder} in {@link QueryStage} with the config set.
      */
+    @CheckReturnValue
     default QueryStage<T> configure(QueryBuilderConfig config) {
         return configure(new AtomicReference<>(config));
     }
@@ -39,6 +41,7 @@ public interface ConfigurationStage<T> {
      * @param config The config of the {@link QueryBuilder}
      * @return The {@link QueryBuilder} in {@link QueryStage} with the config set.
      */
+    @CheckReturnValue
     QueryStage<T> configure(AtomicReference<QueryBuilderConfig> config);
 
     /**
@@ -50,6 +53,7 @@ public interface ConfigurationStage<T> {
      *
      * @return The {@link QueryBuilder} in  {@link QueryStage} with the config set.
      */
+    @CheckReturnValue
     QueryStage<T> defaultConfig();
 
     /**
@@ -59,5 +63,6 @@ public interface ConfigurationStage<T> {
      *
      * @return The {@link QueryBuilder} in {@link QueryStage} with the config set.
      */
+    @CheckReturnValue
     QueryStage<T> defaultConfig(Consumer<QueryBuilderConfig.Builder> builderModifier);
 }

--- a/sadu-queries/src/main/java/de/chojo/sadu/wrapper/stage/InsertStage.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/wrapper/stage/InsertStage.java
@@ -9,13 +9,14 @@ package de.chojo.sadu.wrapper.stage;
 import de.chojo.sadu.wrapper.QueryBuilderConfig;
 import de.chojo.sadu.wrapper.exception.WrappedQueryExecutionException;
 
+import javax.annotation.CheckReturnValue;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 /**
- * Stage representing the result of a insert statement.
+ * Stage representing the result of an insert statement.
  */
 public interface InsertStage extends UpdateStage {
     /**
@@ -24,6 +25,7 @@ public interface InsertStage extends UpdateStage {
      * @return A {@link CompletableFuture} to retrieve the data.
      * @throws WrappedQueryExecutionException if {@link QueryBuilderConfig#isThrowing()} is set to {@code true} and a exceptions occurs during query building or execution
      */
+    @CheckReturnValue
     CompletableFuture<Optional<Long>> key();
 
     /**
@@ -33,6 +35,7 @@ public interface InsertStage extends UpdateStage {
      * @return A {@link CompletableFuture} to retrieve the data.
      * @throws WrappedQueryExecutionException if {@link QueryBuilderConfig#isThrowing()} is set to {@code true} and a exceptions occurs during query building or execution
      */
+    @CheckReturnValue
     CompletableFuture<Optional<Long>> key(Executor executor);
 
     /**
@@ -41,6 +44,7 @@ public interface InsertStage extends UpdateStage {
      * @return result wrapped into an optional
      * @throws WrappedQueryExecutionException if {@link QueryBuilderConfig#isThrowing()} is set to {@code true} and a exceptions occurs during query building or execution
      */
+    @CheckReturnValue
     Optional<Long> keySync();
 
     /**
@@ -49,6 +53,7 @@ public interface InsertStage extends UpdateStage {
      * @return A list of created key.
      * @throws WrappedQueryExecutionException if {@link QueryBuilderConfig#isThrowing()} is set to {@code true} and a exceptions occurs during query building or execution
      */
+    @CheckReturnValue
     List<Long> keysSync();
 
     /**
@@ -57,6 +62,7 @@ public interface InsertStage extends UpdateStage {
      * @return A {@link CompletableFuture} to retrieve the data.
      * @throws WrappedQueryExecutionException if {@link QueryBuilderConfig#isThrowing()} is set to {@code true} and a exceptions occurs during query building or execution
      */
+    @CheckReturnValue
     CompletableFuture<List<Long>> keys();
 
     /**
@@ -66,5 +72,6 @@ public interface InsertStage extends UpdateStage {
      * @return A {@link CompletableFuture} to retrieve the data.
      * @throws WrappedQueryExecutionException if {@link QueryBuilderConfig#isThrowing()} is set to {@code true} and a exceptions occurs during query building or execution
      */
+    @CheckReturnValue
     CompletableFuture<List<Long>> keys(Executor executor);
 }

--- a/sadu-queries/src/main/java/de/chojo/sadu/wrapper/stage/QueryStage.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/wrapper/stage/QueryStage.java
@@ -8,6 +8,8 @@ package de.chojo.sadu.wrapper.stage;
 
 import de.chojo.sadu.wrapper.QueryBuilder;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * Query stage of a {@link QueryBuilder}
  *
@@ -20,6 +22,7 @@ public interface QueryStage<T> {
      * @param sql query to set.
      * @return The {@link QueryBuilder} in a {@link StatementStage} with the query defined.
      */
+    @CheckReturnValue
     StatementStage<T> query(String sql);
 
     /**
@@ -30,6 +33,7 @@ public interface QueryStage<T> {
      *                <b>Do not use this with user input! This should be only used to insert column or table names at runtime</b>
      * @return The {@link QueryBuilder} in a {@link StatementStage} with the query defined.
      */
+    @CheckReturnValue
     default StatementStage<T> query(String sql, Object... objects) {
         return query(String.format(sql, objects));
     }
@@ -42,6 +46,7 @@ public interface QueryStage<T> {
      * @param sql query to set.
      * @return The {@link QueryBuilder} in a {@link ResultStage} with the query defined and no parameter set.
      */
+    @CheckReturnValue
     ResultStage<T> queryWithoutParams(String sql);
 
     /**
@@ -54,6 +59,7 @@ public interface QueryStage<T> {
      *                <b>Do not use this with user input! This should be only used to insert column or table names at runtime</b>
      * @return The {@link QueryBuilder} in a {@link ResultStage} with the query defined and no parameter set.
      */
+    @CheckReturnValue
     default ResultStage<T> queryWithoutParams(String sql, Object... objects) {
         return queryWithoutParams(String.format(sql, objects));
     }

--- a/sadu-queries/src/main/java/de/chojo/sadu/wrapper/stage/ResultStage.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/wrapper/stage/ResultStage.java
@@ -12,6 +12,7 @@ import de.chojo.sadu.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.wrapper.QueryBuilder;
 import de.chojo.sadu.wrapper.util.Row;
 
+import javax.annotation.CheckReturnValue;
 import java.sql.SQLException;
 import java.util.function.Consumer;
 
@@ -30,6 +31,7 @@ public interface ResultStage<T> {
      * @param mapper mapper to map the current row.
      * @return The {@link QueryBuilder} in a {@link RetrievalStage} to retrieve the row/s.
      */
+    @CheckReturnValue
     RetrievalStage<T> readRow(ThrowingFunction<T, Row, SQLException> mapper);
 
     /**
@@ -72,6 +74,7 @@ public interface ResultStage<T> {
      *
      * @return The {@link QueryBuilder} in a {@link UpdateStage} to update the data.
      */
+    @CheckReturnValue
     UpdateStage update();
 
     /**
@@ -79,6 +82,7 @@ public interface ResultStage<T> {
      *
      * @return The {@link QueryBuilder} in a {@link UpdateStage} to update the data.
      */
+    @CheckReturnValue
     default UpdateStage delete() {
         return update();
     }
@@ -88,6 +92,7 @@ public interface ResultStage<T> {
      *
      * @return The {@link QueryBuilder} in a {@link InsertStage} to update the data.
      */
+    @CheckReturnValue
     InsertStage insert();
 
 
@@ -96,5 +101,6 @@ public interface ResultStage<T> {
      *
      * @return The {@link QueryBuilder} in a {@link QueryStage}
      */
+    @CheckReturnValue
     QueryStage<T> append();
 }

--- a/sadu-queries/src/main/java/de/chojo/sadu/wrapper/stage/ResultStage.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/wrapper/stage/ResultStage.java
@@ -7,9 +7,9 @@
 package de.chojo.sadu.wrapper.stage;
 
 import de.chojo.sadu.exceptions.ThrowingFunction;
+import de.chojo.sadu.mapper.MapperConfig;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.wrapper.QueryBuilder;
-import de.chojo.sadu.wrapper.mapper.MapperConfig;
-import de.chojo.sadu.wrapper.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.wrapper.util.Row;
 
 import java.sql.SQLException;

--- a/sadu-queries/src/main/java/de/chojo/sadu/wrapper/stage/RetrievalStage.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/wrapper/stage/RetrievalStage.java
@@ -10,6 +10,7 @@ import de.chojo.sadu.wrapper.QueryBuilder;
 import de.chojo.sadu.wrapper.QueryBuilderConfig;
 import de.chojo.sadu.wrapper.exception.WrappedQueryExecutionException;
 
+import javax.annotation.CheckReturnValue;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -32,6 +33,7 @@ public interface RetrievalStage<T> {
      * @return A {@link CompletableFuture} to retrieve the data.
      * @throws WrappedQueryExecutionException if {@link QueryBuilderConfig#isThrowing()} is set to {@code true} and a exceptions occurs during query building or execution
      */
+    @CheckReturnValue
     CompletableFuture<List<T>> all();
 
     /**
@@ -41,6 +43,7 @@ public interface RetrievalStage<T> {
      * @return A {@link CompletableFuture} to retrieve the data.
      * @throws WrappedQueryExecutionException if {@link QueryBuilderConfig#isThrowing()} is set to {@code true} and a exceptions occurs during query building or execution
      */
+    @CheckReturnValue
     CompletableFuture<List<T>> all(Executor executor);
 
     /**
@@ -49,6 +52,7 @@ public interface RetrievalStage<T> {
      * @return results as list
      * @throws WrappedQueryExecutionException if {@link QueryBuilderConfig#isThrowing()} is set to {@code true} and a exceptions occurs during query building or execution
      */
+    @CheckReturnValue
     List<T> allSync();
 
     /**
@@ -57,6 +61,7 @@ public interface RetrievalStage<T> {
      * @return A {@link CompletableFuture} to retrieve the data.
      * @throws WrappedQueryExecutionException if {@link QueryBuilderConfig#isThrowing()} is set to {@code true} and a exceptions occurs during query building or execution
      */
+    @CheckReturnValue
     CompletableFuture<Optional<T>> first();
 
     /**
@@ -66,6 +71,7 @@ public interface RetrievalStage<T> {
      * @return A {@link CompletableFuture} to retrieve the data.
      * @throws WrappedQueryExecutionException if {@link QueryBuilderConfig#isThrowing()} is set to {@code true} and a exceptions occurs during query building or execution
      */
+    @CheckReturnValue
     CompletableFuture<Optional<T>> first(Executor executor);
 
     /**
@@ -74,5 +80,6 @@ public interface RetrievalStage<T> {
      * @return result wrapped into an optional
      * @throws WrappedQueryExecutionException if {@link QueryBuilderConfig#isThrowing()} is set to {@code true} and a exceptions occurs during query building or execution
      */
+    @CheckReturnValue
     Optional<T> firstSync();
 }

--- a/sadu-queries/src/main/java/de/chojo/sadu/wrapper/stage/StatementStage.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/wrapper/stage/StatementStage.java
@@ -10,6 +10,7 @@ import de.chojo.sadu.exceptions.ThrowingConsumer;
 import de.chojo.sadu.wrapper.QueryBuilder;
 import de.chojo.sadu.wrapper.util.ParamBuilder;
 
+import javax.annotation.CheckReturnValue;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
@@ -27,6 +28,7 @@ public interface StatementStage<T> {
      * @deprecated This method exists for the sole purpose of backwards compatibility. Usage of {@link #parameter(ThrowingConsumer)} is prefered.
      */
     @Deprecated
+    @CheckReturnValue
     ResultStage<T> params(ThrowingConsumer<PreparedStatement, SQLException> stmt);
 
     /**
@@ -41,6 +43,7 @@ public interface StatementStage<T> {
      * @deprecated use {@link #parameter(ThrowingConsumer)} instead
      */
     @Deprecated(forRemoval = true)
+    @CheckReturnValue
     default ResultStage<T> paramsBuilder(ThrowingConsumer<ParamBuilder, SQLException> params) {
         return parameter(params);
     }
@@ -55,6 +58,7 @@ public interface StatementStage<T> {
      * @param stmt a consumer of a param builder used for simple setting of params.
      * @return The {@link QueryBuilder} in a {@link ResultStage} with the parameters applied to the query.
      */
+    @CheckReturnValue
     ResultStage<T> parameter(ThrowingConsumer<ParamBuilder, SQLException> stmt);
 
     /**
@@ -64,6 +68,7 @@ public interface StatementStage<T> {
      *
      * @return The {@link QueryBuilder} in a {@link ResultStage} with no parameters set.
      */
+    @CheckReturnValue
     default ResultStage<T> emptyParams() {
         return params(s -> {
         });

--- a/sadu-queries/src/main/java/de/chojo/sadu/wrapper/util/ParamBuilder.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/wrapper/util/ParamBuilder.java
@@ -306,6 +306,27 @@ public class ParamBuilder {
     }
 
     /**
+     * Sets the designated parameter to the given Java {@code Enum} name value.
+     * The driver converts this
+     * to an SQL {@code VARCHAR} or {@code LONGVARCHAR} value
+     * (depending on the argument's
+     * size relative to the driver's limits on {@code VARCHAR} values)
+     * when it sends it to the database.
+     *
+     * @param x the parameter value
+     * @param <T> Type of enum
+     * @return ParamBuilder with values set.
+     * @throws SQLException if parameterIndex does not correspond to a parameter
+     *                      marker in the SQL statement; if a database access error occurs or
+     *                      this method is called on a closed {@code PreparedStatement}
+     */
+    public <T extends Enum<?>> ParamBuilder setEnum(T x) throws SQLException {
+        if (x == null) return setNull(Types.VARCHAR);
+        stmt.setString(index(), x.name());
+        return this;
+    }
+
+    /**
      * Sets the designated parameter to the given Java array of bytes.  The driver converts
      * this to an SQL {@code VARBINARY} or {@code LONGVARBINARY}
      * (depending on the argument's size relative to the driver's limits on

--- a/sadu-queries/src/test/java/de/chojo/sadu/wrapper/mapper/Mapper.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/wrapper/mapper/Mapper.java
@@ -6,7 +6,7 @@
 
 package de.chojo.sadu.wrapper.mapper;
 
-import de.chojo.sadu.wrapper.mapper.rowmapper.RowMapper;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
 
 public class Mapper {
     public static final RowMapper<Result> wildcard = RowMapper.forClass(Result.class)

--- a/sadu-queries/src/test/java/de/chojo/sadu/wrapper/mapper/RowMapperRegistryTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/wrapper/mapper/RowMapperRegistryTest.java
@@ -6,13 +6,15 @@
 
 package de.chojo.sadu.wrapper.mapper;
 
+import de.chojo.sadu.mapper.MapperConfig;
+import de.chojo.sadu.mapper.RowMapperRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RowMapperRegistryTest {

--- a/sadu-queries/src/test/java/de/chojo/sadu/wrapper/mapper/RowMapperTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/wrapper/mapper/RowMapperTest.java
@@ -6,8 +6,10 @@
 
 package de.chojo.sadu.wrapper.mapper;
 
+import de.chojo.sadu.mapper.MapperConfig;
+import de.chojo.sadu.mapper.RowMapperRegistry;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.wrapper.QueryBuilder;
-import de.chojo.sadu.wrapper.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.wrapper.util.Row;
 import org.junit.jupiter.api.Test;
 

--- a/sadu-sqlite/src/main/java/de/chojo/sadu/mapper/SqLiteMapper.java
+++ b/sadu-sqlite/src/main/java/de/chojo/sadu/mapper/SqLiteMapper.java
@@ -1,0 +1,41 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2022 RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.mapper;
+
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
+
+import java.util.List;
+import java.util.UUID;
+
+import static de.chojo.sadu.mapper.DefaultMapper.createBoolean;
+import static de.chojo.sadu.mapper.DefaultMapper.createBytes;
+import static de.chojo.sadu.mapper.DefaultMapper.createDouble;
+import static de.chojo.sadu.mapper.DefaultMapper.createFloat;
+import static de.chojo.sadu.mapper.DefaultMapper.createInteger;
+import static de.chojo.sadu.mapper.DefaultMapper.createLong;
+import static de.chojo.sadu.mapper.DefaultMapper.createString;
+import static de.chojo.sadu.mapper.DefaultMapper.createUuid;
+import static de.chojo.sadu.types.SqLiteTypes.*;
+
+public final class SqLiteMapper {
+    private SqLiteMapper() {
+        throw new UnsupportedOperationException("This is a utility class.");
+    }
+
+    public static final RowMapper<Boolean> BOOLEAN_MAPPER = createBoolean(List.of(BOOLEAN));
+    public static final RowMapper<Integer> INTEGER_MAPPER = createInteger(List.of(INTEGER));
+    public static final RowMapper<Long> LONG_MAPPER = createLong(List.of(INTEGER));
+    public static final RowMapper<Float> FLOAT_MAPPER = createFloat(List.of(REAL));
+    public static final RowMapper<Double> DOUBLE_MAPPER = createDouble(List.of(REAL));
+    public static final RowMapper<String> STRING_MAPPER = createString(List.of(TEXT));
+    public static final RowMapper<Byte[]> BYTES_MAPPER = createBytes(List.of(BLOB));
+    public static final RowMapper<UUID> UUID_MAPPER = createUuid(List.of(TEXT), List.of(BLOB));
+
+    public static List<RowMapper<?>> getDefaultMapper() {
+        return List.of(BOOLEAN_MAPPER, INTEGER_MAPPER, LONG_MAPPER, FLOAT_MAPPER, DOUBLE_MAPPER, STRING_MAPPER, BYTES_MAPPER, UUID_MAPPER);
+    }
+}

--- a/sadu-sqlite/src/main/java/de/chojo/sadu/types/SqLiteTypes.java
+++ b/sadu-sqlite/src/main/java/de/chojo/sadu/types/SqLiteTypes.java
@@ -28,9 +28,9 @@ public interface SqLiteTypes {
      * SqLite boolean type
      * Internally interpreted as an INTEGER
      */
-    SqlType BOOLEAN = ofName("BOOLEAN");
+    SqlType BOOLEAN = ofName("BOOLEAN", "INTEGER");
     /**
      * SqLite blob type
      */
-    SqlType BLOB = ofName("BOOLEAN");
+    SqlType BLOB = ofName("BLOB");
 }

--- a/sadu-updater/src/main/java/de/chojo/sadu/updater/SqlUpdater.java
+++ b/sadu-updater/src/main/java/de/chojo/sadu/updater/SqlUpdater.java
@@ -13,6 +13,7 @@ import de.chojo.sadu.wrapper.QueryBuilderConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.CheckReturnValue;
 import javax.sql.DataSource;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -125,6 +126,7 @@ public class SqlUpdater<T extends JdbcConfig<?>> extends QueryFactory {
      * @return new builder instance
      * @throws IOException if the version file does not exist.
      */
+    @CheckReturnValue
     public static <T extends JdbcConfig<?>> SqlUpdaterBuilder builder(DataSource dataSource, Database<T> type) throws IOException {
         var version = "";
         try (var versionFile = SqlUpdater.class.getClassLoader().getResourceAsStream("database/version")) {
@@ -366,6 +368,7 @@ public class SqlUpdater<T extends JdbcConfig<?>> extends QueryFactory {
          * @param schemas schemas
          * @return builder instance
          */
+        @CheckReturnValue
         public SqlUpdaterBuilder<T> setSchemas(String... schemas) {
             if (!type.hasSchemas()) {
                 throw new IllegalStateException("This sql type does not support schemas");
@@ -383,6 +386,7 @@ public class SqlUpdater<T extends JdbcConfig<?>> extends QueryFactory {
          * @param versionTable name of the version table
          * @return builder instance
          */
+        @CheckReturnValue
         public SqlUpdaterBuilder<T> setVersionTable(String versionTable) {
             this.versionTable = versionTable;
             return this;
@@ -395,6 +399,7 @@ public class SqlUpdater<T extends JdbcConfig<?>> extends QueryFactory {
          * @param replacements replacements
          * @return builder instance
          */
+        @CheckReturnValue
         public SqlUpdaterBuilder<T> setReplacements(QueryReplacement... replacements) {
             this.replacements = replacements;
             return this;
@@ -406,6 +411,7 @@ public class SqlUpdater<T extends JdbcConfig<?>> extends QueryFactory {
          * @param config config so apply
          * @return builder instance
          */
+        @CheckReturnValue
         public SqlUpdaterBuilder<T> withConfig(QueryBuilderConfig config) {
             this.config = config;
             return this;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ include("sadu-mysql")
 include("sadu-datasource")
 include("sadu-queries")
 include("sadu-updater")
-
+include("sadu-mapper")
 include("sadu-examples")
 
 pluginManagement{


### PR DESCRIPTION
Add the checkReturnType annotation where applicable.

This should decrease the amount of not correctly initialized query builder and SqlUpdater