### PR TITLE
Allow to inject classloader

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 
 publishData {
     useEldoNexusRepos(false)
-    publishingVersion = "1.4.0"
+    publishingVersion = "1.4.1"
 }
 
 group = "de.chojo.sadu"

--- a/sadu-core/src/main/java/de/chojo/sadu/updater/SqlVersion.java
+++ b/sadu-core/src/main/java/de/chojo/sadu/updater/SqlVersion.java
@@ -8,6 +8,9 @@ package de.chojo.sadu.updater;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 /**
  * Class representing a version maintained by the SqlUpdaterBuilder
  * <p>
@@ -84,5 +87,20 @@ public class SqlVersion implements Comparable<SqlVersion> {
             return compare;
         }
         return Integer.compare(patch, o.patch);
+    }
+
+    public static SqlVersion load() throws IOException {
+        return load(SqlVersion.class.getClassLoader());
+    }
+
+    public static SqlVersion load(ClassLoader classLoader) throws IOException {
+        var version = "";
+        try (var versionFile = classLoader.getResourceAsStream("database/version")) {
+            version = new String(versionFile.readAllBytes(), StandardCharsets.UTF_8).trim();
+        }
+
+        var ver = version.split("\\.");
+        return new SqlVersion(Integer.parseInt(ver[0]), Integer.parseInt(ver[1]));
+
     }
 }

--- a/sadu-core/src/main/java/de/chojo/sadu/updater/UpdaterBuilder.java
+++ b/sadu-core/src/main/java/de/chojo/sadu/updater/UpdaterBuilder.java
@@ -13,6 +13,21 @@ import javax.sql.DataSource;
 
 @ApiStatus.Internal
 public interface UpdaterBuilder<T extends JdbcConfig<?>, S extends UpdaterBuilder<T, ?>> {
-    void setSource(DataSource source);
-    void setVersion(SqlVersion version);
+    /**
+     * Set the datasource that should be used
+     * @param source source
+     */
+    S setSource(DataSource source);
+
+    /**
+     * Set the current db version that is expected
+     * @param version version
+     */
+    S setVersion(SqlVersion version);
+
+    /**
+     * Set the Classloader that should be used to load resourced.
+     * @param classLoader classloader
+     */
+    S withClassLoader(ClassLoader classLoader);
 }

--- a/sadu-postgresql/src/main/java/de/chojo/sadu/update/PostgreSqlUpdater.java
+++ b/sadu-postgresql/src/main/java/de/chojo/sadu/update/PostgreSqlUpdater.java
@@ -28,8 +28,8 @@ public class PostgreSqlUpdater extends SqlUpdater<PostgreSqlJdbc, PostgreSqlUpda
 
     private final String[] schemas;
 
-    protected PostgreSqlUpdater(DataSource source, QueryBuilderConfig config, String versionTable, QueryReplacement[] replacements, SqlVersion version, Database<PostgreSqlJdbc, PostgreSqlUpdaterBuilder> type, String[] schemas, Map<SqlVersion, Consumer<Connection>> preUpdateHook, Map<SqlVersion, Consumer<Connection>> postUpdateHook) {
-        super(source, config, versionTable, replacements, version, type, preUpdateHook, postUpdateHook);
+    protected PostgreSqlUpdater(DataSource source, QueryBuilderConfig config, String versionTable, QueryReplacement[] replacements, SqlVersion version, Database<PostgreSqlJdbc, PostgreSqlUpdaterBuilder> type, String[] schemas, Map<SqlVersion, Consumer<Connection>> preUpdateHook, Map<SqlVersion, Consumer<Connection>> postUpdateHook, ClassLoader classLoader) {
+        super(source, config, versionTable, replacements, version, type, preUpdateHook, postUpdateHook, classLoader);
         this.schemas = schemas;
     }
 

--- a/sadu-postgresql/src/main/java/de/chojo/sadu/update/PostgreSqlUpdaterBuilder.java
+++ b/sadu-postgresql/src/main/java/de/chojo/sadu/update/PostgreSqlUpdaterBuilder.java
@@ -9,6 +9,7 @@ package de.chojo.sadu.update;
 import de.chojo.sadu.databases.Database;
 import de.chojo.sadu.jdbc.PostgreSqlJdbc;
 import de.chojo.sadu.updater.BaseSqlUpdaterBuilder;
+import de.chojo.sadu.updater.SqlVersion;
 
 import javax.annotation.CheckReturnValue;
 import java.io.IOException;
@@ -39,6 +40,7 @@ public class PostgreSqlUpdaterBuilder extends BaseSqlUpdaterBuilder<PostgreSqlJd
 
     @Override
     public void execute() throws SQLException, IOException {
+        if (version == null) version = SqlVersion.load(classLoader);
         var updater = new PostgreSqlUpdater(source, config, versionTable, replacements, version, type, schemas, preUpdateHook, postUpdateHook, classLoader);
         updater.init();
     }

--- a/sadu-postgresql/src/main/java/de/chojo/sadu/update/PostgreSqlUpdaterBuilder.java
+++ b/sadu-postgresql/src/main/java/de/chojo/sadu/update/PostgreSqlUpdaterBuilder.java
@@ -39,7 +39,7 @@ public class PostgreSqlUpdaterBuilder extends BaseSqlUpdaterBuilder<PostgreSqlJd
 
     @Override
     public void execute() throws SQLException, IOException {
-        var updater = new PostgreSqlUpdater(source, config, versionTable, replacements, version, type, schemas, preUpdateHook, postUpdateHook);
+        var updater = new PostgreSqlUpdater(source, config, versionTable, replacements, version, type, schemas, preUpdateHook, postUpdateHook, classLoader);
         updater.init();
     }
 }

--- a/sadu-updater/src/main/java/de/chojo/sadu/updater/SqlUpdater.java
+++ b/sadu-updater/src/main/java/de/chojo/sadu/updater/SqlUpdater.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -113,11 +114,11 @@ public class SqlUpdater<T extends JdbcConfig<?>, U extends BaseSqlUpdaterBuilder
 
     protected SqlUpdater(DataSource source, QueryBuilderConfig config, String versionTable, QueryReplacement[] replacements, SqlVersion version, Database<T, U> type, Map<SqlVersion, Consumer<Connection>> preUpdateHook, Map<SqlVersion, Consumer<Connection>> postUpdateHook, ClassLoader classLoader) {
         super(source, config);
-        this.source = source;
+        this.source = Objects.requireNonNull(source);
         this.versionTable = versionTable;
         this.replacements = replacements;
-        this.type = type;
-        this.version = version;
+        this.type = Objects.requireNonNull(type);
+        this.version = Objects.requireNonNull(version);
         this.preUpdateHook = preUpdateHook;
         this.postUpdateHook = postUpdateHook;
         this.classLoader = classLoader;

--- a/sadu-updater/src/main/java/de/chojo/sadu/updater/SqlUpdater.java
+++ b/sadu-updater/src/main/java/de/chojo/sadu/updater/SqlUpdater.java
@@ -109,8 +109,9 @@ public class SqlUpdater<T extends JdbcConfig<?>, U extends BaseSqlUpdaterBuilder
     private final String versionTable;
     private final QueryReplacement[] replacements;
     private final Database<T, U> type;
+    private final ClassLoader classLoader;
 
-    protected SqlUpdater(DataSource source, QueryBuilderConfig config, String versionTable, QueryReplacement[] replacements, SqlVersion version, Database<T, U> type, Map<SqlVersion, Consumer<Connection>> preUpdateHook, Map<SqlVersion, Consumer<Connection>> postUpdateHook) {
+    protected SqlUpdater(DataSource source, QueryBuilderConfig config, String versionTable, QueryReplacement[] replacements, SqlVersion version, Database<T, U> type, Map<SqlVersion, Consumer<Connection>> preUpdateHook, Map<SqlVersion, Consumer<Connection>> postUpdateHook, ClassLoader classLoader) {
         super(source, config);
         this.source = source;
         this.versionTable = versionTable;
@@ -119,6 +120,7 @@ public class SqlUpdater<T extends JdbcConfig<?>, U extends BaseSqlUpdaterBuilder
         this.version = version;
         this.preUpdateHook = preUpdateHook;
         this.postUpdateHook = postUpdateHook;
+        this.classLoader = classLoader;
     }
 
     /**
@@ -134,13 +136,7 @@ public class SqlUpdater<T extends JdbcConfig<?>, U extends BaseSqlUpdaterBuilder
      */
     @CheckReturnValue
     public static <T extends JdbcConfig<?>, U extends UpdaterBuilder<T, ?>> U builder(DataSource dataSource, Database<T, U> type) throws IOException {
-        var version = "";
-        try (var versionFile = SqlUpdater.class.getClassLoader().getResourceAsStream("database/version")) {
-            version = new String(versionFile.readAllBytes(), StandardCharsets.UTF_8).trim();
-        }
-
-        var ver = version.split("\\.");
-        return builder(dataSource, new SqlVersion(Integer.parseInt(ver[0]), Integer.parseInt(ver[1])), type);
+        return (U) type.newSqlUpdaterBuilder().setSource(dataSource);
     }
 
     /**
@@ -151,7 +147,9 @@ public class SqlUpdater<T extends JdbcConfig<?>, U extends BaseSqlUpdaterBuilder
      * @param type       the sql type of the database
      * @param <T>        type of the database defined by the {@link Database}
      * @return builder instance
+     * @deprecated Use {{@link #builder(DataSource, Database)}} and use {@link UpdaterBuilder#setVersion(SqlVersion)}.
      */
+    @Deprecated(forRemoval = true)
     public static <T extends JdbcConfig<?>, U extends UpdaterBuilder<T, ?>> U builder(DataSource dataSource, SqlVersion version, Database<T, U> type) {
         var builder = type.newSqlUpdaterBuilder();
         builder.setSource(dataSource);
@@ -318,8 +316,7 @@ public class SqlUpdater<T extends JdbcConfig<?>, U extends BaseSqlUpdaterBuilder
     }
 
     private boolean patchExists(int major, int patch) {
-        return getClass().getClassLoader()
-                         .getResource("database/" + type.name() + "/" + major + "/patch_" + patch + ".sql") != null;
+        return classLoader.getResource("database/" + type.name() + "/" + major + "/patch_" + patch + ".sql") != null;
     }
 
     private String loadPatch(int major, int patch) throws IOException {
@@ -328,7 +325,7 @@ public class SqlUpdater<T extends JdbcConfig<?>, U extends BaseSqlUpdaterBuilder
 
     private String loadFromResource(Object... path) throws IOException {
         var patch = Arrays.stream(path).map(Object::toString).collect(Collectors.joining("/"));
-        try (var patchFile = getClass().getClassLoader().getResourceAsStream("database/" + type.name() + "/" + patch)) {
+        try (var patchFile = classLoader.getResourceAsStream("database/" + type.name() + "/" + patch)) {
             log.info("Loading resource {}", "database/" + type.name() + "/" + patch);
             return new String(patchFile.readAllBytes(), StandardCharsets.UTF_8);
         }


### PR DESCRIPTION
When sadu is loaded via an external classloader (for example spigots library loader) it can not access the resources of the original classloader.
This patch allows to define the classloader that is used to load the resources.