### PR TITLE
Feature: ValueReader & ValueConverter

### DIFF
--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/DefaultMapper.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/DefaultMapper.java
@@ -23,6 +23,9 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static de.chojo.sadu.mapper.reader.StandardReader.UUID_FROM_BYTES;
+import static de.chojo.sadu.mapper.reader.StandardReader.UUID_FROM_STRING;
+
 public final class DefaultMapper {
     private DefaultMapper() {
         throw new UnsupportedOperationException("This is a utility class.");
@@ -70,7 +73,7 @@ public final class DefaultMapper {
                     var meta = row.getMetaData();
                     var columnIndexOfType = Results.getFirstColumnIndexOfType(meta, textTypes);
                     if (columnIndexOfType.isPresent()) {
-                        return row.getUuidFromString(columnIndexOfType.get());
+                        return row.get(columnIndexOfType.get(), UUID_FROM_STRING);
                     }
                     columnIndexOfType = Results.getFirstColumnIndexOfType(meta, byteTypes);
                     var index = columnIndexOfType.orElseThrow(() -> {
@@ -78,7 +81,7 @@ public final class DefaultMapper {
                         sqlTypes.addAll(byteTypes);
                         return createException(sqlTypes, meta);
                     });
-                    return row.getUuidFromBytes(index);
+                    return row.get(index, UUID_FROM_BYTES);
                 })
                 .build();
     }

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/StandardReader.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/StandardReader.java
@@ -6,13 +6,13 @@
 
 package de.chojo.sadu.mapper.reader;
 
-import de.chojo.sadu.core.exceptions.ThrowingBiFunction;
 import de.chojo.sadu.mapper.wrapper.Row;
 
-import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.function.Function;
 
-public class StandardReader {
-    public ValueReader<Long, Instant> INSTANT_FROM_MILLIS = ValueReader.create(Instant::ofEpochMilli, Row::getLong, Row::getLong);
+public final class StandardReader {
+    public static final ValueReader<Long, Instant> INSTANT_FROM_MILLIS = ValueReader.create(Instant::ofEpochMilli, Row::getLong, Row::getLong);
+    public static final ValueReader<Long, Instant> INSTANT_FROM_SECONDS = ValueReader.create(Instant::ofEpochSecond, Row::getLong, Row::getLong);
+    public static final ValueReader<Timestamp, Instant> INSTANT_FROM_TIMESTAMP = ValueReader.create(Timestamp::toInstant, Row::getTimestamp, Row::getTimestamp);
 }

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/StandardReader.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/StandardReader.java
@@ -1,0 +1,18 @@
+/*
+ *     SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *     Copyright (C) RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.mapper.reader;
+
+import de.chojo.sadu.core.exceptions.ThrowingBiFunction;
+import de.chojo.sadu.mapper.wrapper.Row;
+
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.function.Function;
+
+public class StandardReader {
+    public ValueReader<Long, Instant> INSTANT_FROM_MILLIS = ValueReader.create(Instant::ofEpochMilli, Row::getLong, Row::getLong);
+}

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/StandardReader.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/StandardReader.java
@@ -8,6 +8,8 @@ package de.chojo.sadu.mapper.reader;
 
 import de.chojo.sadu.core.conversion.UUIDConverter;
 import de.chojo.sadu.mapper.wrapper.Row;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 import java.sql.Date;
 import java.sql.Time;
@@ -39,31 +41,38 @@ public final class StandardReader {
     public static final ValueReader<UUID, String> UUID_FROM_STRING = ValueReader.create(UUID::fromString, Row::getString, Row::getString);
     public static final ValueReader<UUID, byte[]> UUID_FROM_BYTES = ValueReader.create(UUIDConverter::convert, Row::getBytes, Row::getBytes);
 
-    public static ValueReader<LocalDate, Date> localDate(Calendar calendar) {
+    @Contract(value = "_ -> new", pure = true)
+    public static @NotNull ValueReader<LocalDate, Date> localDate(Calendar calendar) {
         return ValueReader.create(Date::toLocalDate, (row, name) -> row.getDate(name, calendar), (row, integer) -> row.getDate(integer, calendar));
     }
 
-    public static ValueReader<LocalTime, Time> localTime(Calendar calendar) {
+    @Contract(value = "_ -> new", pure = true)
+    public static @NotNull ValueReader<LocalTime, Time> localTime(Calendar calendar) {
         return ValueReader.create(Time::toLocalTime, (row, name) -> row.getTime(name, calendar), (row, integer) -> row.getTime(integer, calendar));
     }
 
-    public static ValueReader<OffsetTime, Time> offsetTime(Calendar calendar) {
+    @Contract(value = "_ -> new", pure = true)
+    public static @NotNull ValueReader<OffsetTime, Time> offsetTime(Calendar calendar) {
         return ValueReader.create(t -> t.toLocalTime().atOffset(OffsetTime.now().getOffset()), (row, name) -> row.getTime(name, calendar), (row, integer) -> row.getTime(integer, calendar));
     }
 
-    public static ValueReader<LocalDateTime, Timestamp> localDateTime(Calendar calendar) {
+    @Contract(value = "_ -> new", pure = true)
+    public static @NotNull ValueReader<LocalDateTime, Timestamp> localDateTime(Calendar calendar) {
         return ValueReader.create(Timestamp::toLocalDateTime, (row, name) -> row.getTimestamp(name, calendar), (row, integer) -> row.getTimestamp(integer, calendar));
     }
 
-    public static ValueReader<OffsetDateTime, Timestamp> offsetDateTime(Calendar calendar) {
+    @Contract(value = "_ -> new", pure = true)
+    public static @NotNull ValueReader<OffsetDateTime, Timestamp> offsetDateTime(Calendar calendar) {
         return ValueReader.create(t -> OffsetDateTime.ofInstant(t.toInstant(), ZoneId.systemDefault()), (row, name) -> row.getTimestamp(name, calendar), (row, integer) -> row.getTimestamp(integer, calendar));
     }
 
-    public static ValueReader<ZonedDateTime, Timestamp> zonedDateTime(Calendar calendar) {
+    @Contract(value = "_ -> new", pure = true)
+    public static @NotNull ValueReader<ZonedDateTime, Timestamp> zonedDateTime(Calendar calendar) {
         return ValueReader.create(t -> t.toInstant().atZone(ZoneId.systemDefault()), (row, name) -> row.getTimestamp(name, calendar), (row, integer) -> row.getTimestamp(integer, calendar));
     }
 
-    public static <T extends Enum<T>> ValueReader<T, String> forEnum(Class<T> clazz) {
+    @Contract(value = "_ -> new", pure = true)
+    public static <T extends Enum<T>> @NotNull ValueReader<T, String> forEnum(Class<T> clazz) {
         return ValueReader.create(v -> Enum.valueOf(clazz, v), Row::getString, Row::getString);
     }
 }

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/StandardReader.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/StandardReader.java
@@ -6,13 +6,64 @@
 
 package de.chojo.sadu.mapper.reader;
 
+import de.chojo.sadu.core.conversion.UUIDConverter;
 import de.chojo.sadu.mapper.wrapper.Row;
 
+import java.sql.Date;
+import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.UUID;
 
+/**
+ * Default implementations of {@link ValueReader}.
+ */
 public final class StandardReader {
     public static final ValueReader<Long, Instant> INSTANT_FROM_MILLIS = ValueReader.create(Instant::ofEpochMilli, Row::getLong, Row::getLong);
     public static final ValueReader<Long, Instant> INSTANT_FROM_SECONDS = ValueReader.create(Instant::ofEpochSecond, Row::getLong, Row::getLong);
     public static final ValueReader<Timestamp, Instant> INSTANT_FROM_TIMESTAMP = ValueReader.create(Timestamp::toInstant, Row::getTimestamp, Row::getTimestamp);
+    public static final ValueReader<Timestamp, LocalDateTime> LOCAL_DATE_TIME = ValueReader.create(Timestamp::toLocalDateTime, Row::getTimestamp, Row::getTimestamp);
+    public static final ValueReader<Timestamp, OffsetDateTime> OFFSET_DATE_TIME = ValueReader.create(t -> OffsetDateTime.ofInstant(t.toInstant(), ZoneId.systemDefault()), Row::getTimestamp, Row::getTimestamp);
+    public static final ValueReader<Timestamp, ZonedDateTime> ZONED_DATE_TIME = ValueReader.create(t -> t.toInstant().atZone(ZoneId.systemDefault()), Row::getTimestamp, Row::getTimestamp);
+    public static final ValueReader<Time, OffsetTime> OFFSET_TIME = ValueReader.create(t -> t.toLocalTime().atOffset(OffsetTime.now().getOffset()), Row::getTime, Row::getTime);
+    public static final ValueReader<Date, LocalDate> LOCAL_DATE = ValueReader.create(Date::toLocalDate, Row::getDate, Row::getDate);
+    public static final ValueReader<Time, LocalTime> LOCAL_TIME = ValueReader.create(Time::toLocalTime, Row::getTime, Row::getTime);
+    public static final ValueReader<String, UUID> UUID_FROM_STRING = ValueReader.create(UUID::fromString, Row::getString, Row::getString);
+    public static final ValueReader<byte[], UUID> UUID_FROM_BYTES = ValueReader.create(UUIDConverter::convert, Row::getBytes, Row::getBytes);
+
+    public static ValueReader<Date, LocalDate> localDate(Calendar calendar) {
+        return ValueReader.create(Date::toLocalDate, (row, name) -> row.getDate(name, calendar), (row, integer) -> row.getDate(integer, calendar));
+    }
+
+    public static ValueReader<Time, LocalTime> localTime(Calendar calendar) {
+        return ValueReader.create(Time::toLocalTime, (row, name) -> row.getTime(name, calendar), (row, integer) -> row.getTime(integer, calendar));
+    }
+
+    public static ValueReader<Time, OffsetTime> offsetTime(Calendar calendar) {
+        return ValueReader.create(t -> t.toLocalTime().atOffset(OffsetTime.now().getOffset()), (row, name) -> row.getTime(name, calendar), (row, integer) -> row.getTime(integer, calendar));
+    }
+
+    public static ValueReader<Timestamp, LocalDateTime> localDateTime(Calendar calendar) {
+        return ValueReader.create(Timestamp::toLocalDateTime, (row, name) -> row.getTimestamp(name, calendar), (row, integer) -> row.getTimestamp(integer, calendar));
+    }
+
+    public static ValueReader<Timestamp, OffsetDateTime> offsetDateTime(Calendar calendar) {
+        return ValueReader.create(t -> OffsetDateTime.ofInstant(t.toInstant(), ZoneId.systemDefault()), (row, name) -> row.getTimestamp(name, calendar), (row, integer) -> row.getTimestamp(integer, calendar));
+    }
+
+    public static ValueReader<Timestamp, ZonedDateTime> zonedDateTime(Calendar calendar) {
+        return ValueReader.create(t -> t.toInstant().atZone(ZoneId.systemDefault()), (row, name) -> row.getTimestamp(name, calendar), (row, integer) -> row.getTimestamp(integer, calendar));
+    }
+
+    public static <T extends Enum<T>> ValueReader<String, T> forEnum(Class<T> clazz) {
+        return ValueReader.create(v -> Enum.valueOf(clazz, v), Row::getString, Row::getString);
+    }
 }

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/StandardReader.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/StandardReader.java
@@ -27,43 +27,43 @@ import java.util.UUID;
  * Default implementations of {@link ValueReader}.
  */
 public final class StandardReader {
-    public static final ValueReader<Long, Instant> INSTANT_FROM_MILLIS = ValueReader.create(Instant::ofEpochMilli, Row::getLong, Row::getLong);
-    public static final ValueReader<Long, Instant> INSTANT_FROM_SECONDS = ValueReader.create(Instant::ofEpochSecond, Row::getLong, Row::getLong);
-    public static final ValueReader<Timestamp, Instant> INSTANT_FROM_TIMESTAMP = ValueReader.create(Timestamp::toInstant, Row::getTimestamp, Row::getTimestamp);
-    public static final ValueReader<Timestamp, LocalDateTime> LOCAL_DATE_TIME = ValueReader.create(Timestamp::toLocalDateTime, Row::getTimestamp, Row::getTimestamp);
-    public static final ValueReader<Timestamp, OffsetDateTime> OFFSET_DATE_TIME = ValueReader.create(t -> OffsetDateTime.ofInstant(t.toInstant(), ZoneId.systemDefault()), Row::getTimestamp, Row::getTimestamp);
-    public static final ValueReader<Timestamp, ZonedDateTime> ZONED_DATE_TIME = ValueReader.create(t -> t.toInstant().atZone(ZoneId.systemDefault()), Row::getTimestamp, Row::getTimestamp);
-    public static final ValueReader<Time, OffsetTime> OFFSET_TIME = ValueReader.create(t -> t.toLocalTime().atOffset(OffsetTime.now().getOffset()), Row::getTime, Row::getTime);
-    public static final ValueReader<Date, LocalDate> LOCAL_DATE = ValueReader.create(Date::toLocalDate, Row::getDate, Row::getDate);
-    public static final ValueReader<Time, LocalTime> LOCAL_TIME = ValueReader.create(Time::toLocalTime, Row::getTime, Row::getTime);
-    public static final ValueReader<String, UUID> UUID_FROM_STRING = ValueReader.create(UUID::fromString, Row::getString, Row::getString);
-    public static final ValueReader<byte[], UUID> UUID_FROM_BYTES = ValueReader.create(UUIDConverter::convert, Row::getBytes, Row::getBytes);
+    public static final ValueReader<Instant, Long> INSTANT_FROM_MILLIS = ValueReader.create(Instant::ofEpochMilli, Row::getLong, Row::getLong);
+    public static final ValueReader<Instant, Long> INSTANT_FROM_SECONDS = ValueReader.create(Instant::ofEpochSecond, Row::getLong, Row::getLong);
+    public static final ValueReader<Instant, Timestamp> INSTANT_FROM_TIMESTAMP = ValueReader.create(Timestamp::toInstant, Row::getTimestamp, Row::getTimestamp);
+    public static final ValueReader<LocalDateTime, Timestamp> LOCAL_DATE_TIME = ValueReader.create(Timestamp::toLocalDateTime, Row::getTimestamp, Row::getTimestamp);
+    public static final ValueReader<OffsetDateTime, Timestamp> OFFSET_DATE_TIME = ValueReader.create(t -> OffsetDateTime.ofInstant(t.toInstant(), ZoneId.systemDefault()), Row::getTimestamp, Row::getTimestamp);
+    public static final ValueReader<ZonedDateTime, Timestamp> ZONED_DATE_TIME = ValueReader.create(t -> t.toInstant().atZone(ZoneId.systemDefault()), Row::getTimestamp, Row::getTimestamp);
+    public static final ValueReader<OffsetTime, Time> OFFSET_TIME = ValueReader.create(t -> t.toLocalTime().atOffset(OffsetTime.now().getOffset()), Row::getTime, Row::getTime);
+    public static final ValueReader<LocalDate, Date> LOCAL_DATE = ValueReader.create(Date::toLocalDate, Row::getDate, Row::getDate);
+    public static final ValueReader<LocalTime, Time> LOCAL_TIME = ValueReader.create(Time::toLocalTime, Row::getTime, Row::getTime);
+    public static final ValueReader<UUID, String> UUID_FROM_STRING = ValueReader.create(UUID::fromString, Row::getString, Row::getString);
+    public static final ValueReader<UUID, byte[]> UUID_FROM_BYTES = ValueReader.create(UUIDConverter::convert, Row::getBytes, Row::getBytes);
 
-    public static ValueReader<Date, LocalDate> localDate(Calendar calendar) {
+    public static ValueReader<LocalDate, Date> localDate(Calendar calendar) {
         return ValueReader.create(Date::toLocalDate, (row, name) -> row.getDate(name, calendar), (row, integer) -> row.getDate(integer, calendar));
     }
 
-    public static ValueReader<Time, LocalTime> localTime(Calendar calendar) {
+    public static ValueReader<LocalTime, Time> localTime(Calendar calendar) {
         return ValueReader.create(Time::toLocalTime, (row, name) -> row.getTime(name, calendar), (row, integer) -> row.getTime(integer, calendar));
     }
 
-    public static ValueReader<Time, OffsetTime> offsetTime(Calendar calendar) {
+    public static ValueReader<OffsetTime, Time> offsetTime(Calendar calendar) {
         return ValueReader.create(t -> t.toLocalTime().atOffset(OffsetTime.now().getOffset()), (row, name) -> row.getTime(name, calendar), (row, integer) -> row.getTime(integer, calendar));
     }
 
-    public static ValueReader<Timestamp, LocalDateTime> localDateTime(Calendar calendar) {
+    public static ValueReader<LocalDateTime, Timestamp> localDateTime(Calendar calendar) {
         return ValueReader.create(Timestamp::toLocalDateTime, (row, name) -> row.getTimestamp(name, calendar), (row, integer) -> row.getTimestamp(integer, calendar));
     }
 
-    public static ValueReader<Timestamp, OffsetDateTime> offsetDateTime(Calendar calendar) {
+    public static ValueReader<OffsetDateTime, Timestamp> offsetDateTime(Calendar calendar) {
         return ValueReader.create(t -> OffsetDateTime.ofInstant(t.toInstant(), ZoneId.systemDefault()), (row, name) -> row.getTimestamp(name, calendar), (row, integer) -> row.getTimestamp(integer, calendar));
     }
 
-    public static ValueReader<Timestamp, ZonedDateTime> zonedDateTime(Calendar calendar) {
+    public static ValueReader<ZonedDateTime, Timestamp> zonedDateTime(Calendar calendar) {
         return ValueReader.create(t -> t.toInstant().atZone(ZoneId.systemDefault()), (row, name) -> row.getTimestamp(name, calendar), (row, integer) -> row.getTimestamp(integer, calendar));
     }
 
-    public static <T extends Enum<T>> ValueReader<String, T> forEnum(Class<T> clazz) {
+    public static <T extends Enum<T>> ValueReader<T, String> forEnum(Class<T> clazz) {
         return ValueReader.create(v -> Enum.valueOf(clazz, v), Row::getString, Row::getString);
     }
 }

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/ValueReader.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/ValueReader.java
@@ -42,9 +42,25 @@ public interface ValueReader<T, V> {
         };
     }
 
+    /**
+     * A reader that takes the sql type and converts it into a java type.
+     * The passed sql type instance is never null.
+     *
+     * @return a converted java instance of the sql object
+     */
     Function<@NotNull V, T> reader();
 
+    /**
+     * Function that provides access to a reader that returns the column value via column name
+     *
+     * @return function
+     */
     ThrowingBiFunction<Row, String, V, SQLException> namedReader();
 
+    /**
+     * Function that provides access to a reader that returns the column value via column index
+     *
+     * @return function
+     */
     ThrowingBiFunction<Row, Integer, V, SQLException> indexedReader();
 }

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/ValueReader.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/ValueReader.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
  * @see StandardReader
  */
 public interface ValueReader<V, T> {
-    T parse(V value);
+    Function<@NotNull V,T> parser();
 
     ThrowingBiFunction<Row, String, V, SQLException> namedReader();
 
@@ -32,8 +32,8 @@ public interface ValueReader<V, T> {
                                            ThrowingBiFunction<Row, Integer, V, SQLException> indexReader) {
         return new ValueReader<>() {
             @Override
-            public T parse(@NotNull V value) {
-                return parser.apply(value);
+            public Function<@NotNull V,T> parser() {
+                return parser;
             }
 
             @Override

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/ValueReader.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/ValueReader.java
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.sql.SQLException;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Definition of a ValueReader to read columns from a {@link Row} and parse it to a java type.
@@ -42,6 +43,33 @@ public interface ValueReader<T, V> {
         };
     }
 
+    static <V, T> ValueReader<T, V> create(Function<V, T> parser,
+                                           ThrowingBiFunction<Row, String, V, SQLException> nameReader,
+                                           ThrowingBiFunction<Row, Integer, V, SQLException> indexReader,
+                                           Supplier<T> defaultValue) {
+        return new ValueReader<>() {
+            @Override
+            public Function<@NotNull V, T> reader() {
+                return parser;
+            }
+
+            @Override
+            public ThrowingBiFunction<Row, String, V, SQLException> namedReader() {
+                return nameReader;
+            }
+
+            @Override
+            public ThrowingBiFunction<Row, Integer, V, SQLException> indexedReader() {
+                return indexReader;
+            }
+
+            @Override
+            public T defaultValue() {
+                return defaultValue.get();
+            }
+        };
+    }
+
     /**
      * A reader that takes the sql type and converts it into a java type.
      * The passed sql type instance is never null.
@@ -63,4 +91,13 @@ public interface ValueReader<T, V> {
      * @return function
      */
     ThrowingBiFunction<Row, Integer, V, SQLException> indexedReader();
+
+    /**
+     * A default value that should be returned when the SQL value is null
+     *
+     * @return a default value or null
+     */
+    default T defaultValue() {
+        return null;
+    }
 }

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/ValueReader.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/ValueReader.java
@@ -16,17 +16,17 @@ import java.util.function.Function;
 /**
  * Definition of a ValueReader to read columns from a {@link Row} and parse it to a java type.
  *
- * @param <V>
- * @param <T>
+ * @param <T> The java type that is returned by the adapter
+ * @param <V> The intermediate SQL type that is retrieved from the row
  * @see StandardReader
  */
-public interface ValueReader<V, T> {
-    static <V, T> ValueReader<V, T> create(Function<V, T> parser,
+public interface ValueReader<T, V> {
+    static <V, T> ValueReader<T, V> create(Function<V, T> parser,
                                            ThrowingBiFunction<Row, String, V, SQLException> nameReader,
                                            ThrowingBiFunction<Row, Integer, V, SQLException> indexReader) {
         return new ValueReader<>() {
             @Override
-            public Function<@NotNull V, T> parser() {
+            public Function<@NotNull V, T> reader() {
                 return parser;
             }
 
@@ -42,7 +42,7 @@ public interface ValueReader<V, T> {
         };
     }
 
-    Function<@NotNull V, T> parser();
+    Function<@NotNull V, T> reader();
 
     ThrowingBiFunction<Row, String, V, SQLException> namedReader();
 

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/ValueReader.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/ValueReader.java
@@ -21,18 +21,12 @@ import java.util.function.Function;
  * @see StandardReader
  */
 public interface ValueReader<V, T> {
-    Function<@NotNull V,T> parser();
-
-    ThrowingBiFunction<Row, String, V, SQLException> namedReader();
-
-    ThrowingBiFunction<Row, Integer, V, SQLException> indexedReader();
-
     static <V, T> ValueReader<V, T> create(Function<V, T> parser,
                                            ThrowingBiFunction<Row, String, V, SQLException> nameReader,
                                            ThrowingBiFunction<Row, Integer, V, SQLException> indexReader) {
         return new ValueReader<>() {
             @Override
-            public Function<@NotNull V,T> parser() {
+            public Function<@NotNull V, T> parser() {
                 return parser;
             }
 
@@ -47,4 +41,10 @@ public interface ValueReader<V, T> {
             }
         };
     }
+
+    Function<@NotNull V, T> parser();
+
+    ThrowingBiFunction<Row, String, V, SQLException> namedReader();
+
+    ThrowingBiFunction<Row, Integer, V, SQLException> indexedReader();
 }

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/ValueReader.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/ValueReader.java
@@ -8,12 +8,18 @@ package de.chojo.sadu.mapper.reader;
 
 import de.chojo.sadu.core.exceptions.ThrowingBiFunction;
 import de.chojo.sadu.mapper.wrapper.Row;
+import org.jetbrains.annotations.NotNull;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
+/**
+ * Definition of a ValueReader to read columns from a {@link Row} and parse it to a java type.
+ *
+ * @param <V>
+ * @param <T>
+ * @see StandardReader
+ */
 public interface ValueReader<V, T> {
     T parse(V value);
 
@@ -26,8 +32,7 @@ public interface ValueReader<V, T> {
                                            ThrowingBiFunction<Row, Integer, V, SQLException> indexReader) {
         return new ValueReader<>() {
             @Override
-            public T parse(V value) {
-                if (value == null) return null;
+            public T parse(@NotNull V value) {
                 return parser.apply(value);
             }
 

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/ValueReader.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/reader/ValueReader.java
@@ -1,0 +1,45 @@
+/*
+ *     SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *     Copyright (C) RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.mapper.reader;
+
+import de.chojo.sadu.core.exceptions.ThrowingBiFunction;
+import de.chojo.sadu.mapper.wrapper.Row;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public interface ValueReader<V, T> {
+    T parse(V value);
+
+    ThrowingBiFunction<Row, String, V, SQLException> namedReader();
+
+    ThrowingBiFunction<Row, Integer, V, SQLException> indexedReader();
+
+    static <V, T> ValueReader<V, T> create(Function<V, T> parser,
+                                           ThrowingBiFunction<Row, String, V, SQLException> nameReader,
+                                           ThrowingBiFunction<Row, Integer, V, SQLException> indexReader) {
+        return new ValueReader<>() {
+            @Override
+            public T parse(V value) {
+                if (value == null) return null;
+                return parser.apply(value);
+            }
+
+            @Override
+            public ThrowingBiFunction<Row, String, V, SQLException> namedReader() {
+                return nameReader;
+            }
+
+            @Override
+            public ThrowingBiFunction<Row, Integer, V, SQLException> indexedReader() {
+                return indexReader;
+            }
+        };
+    }
+}

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/wrapper/Row.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/wrapper/Row.java
@@ -2072,7 +2072,7 @@ public class Row {
     public <V, T> T get(String columnLabel, ValueReader<V, T> reader) throws SQLException {
         V value = reader.namedReader().apply(this, columnAlias(columnLabel));
         if (value == null) return null;
-        return reader.parse(value);
+        return reader.parser().apply(value);
     }
 
     /**
@@ -2089,7 +2089,7 @@ public class Row {
      */
     public <V, T> T get(int index, ValueReader<V, T> reader) throws SQLException {
         V value = reader.indexedReader().apply(this, index);
-        return reader.parse(value);
+        return reader.parser().apply(value);
     }
 
     private String columnAlias(String columnLabel) {

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/wrapper/Row.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/wrapper/Row.java
@@ -9,6 +9,7 @@ package de.chojo.sadu.mapper.wrapper;
 import de.chojo.sadu.core.conversion.ArrayConverter;
 import de.chojo.sadu.core.conversion.UUIDConverter;
 import de.chojo.sadu.mapper.MapperConfig;
+import de.chojo.sadu.mapper.reader.StandardReader;
 import de.chojo.sadu.mapper.reader.ValueReader;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -35,6 +36,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.List;
@@ -126,7 +128,9 @@ public class Row {
      *                                  called on a closed result set
      * @throws IllegalArgumentException If value does not conform to the string representation as
      *                                  described in {@link #toString}
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public UUID getUuidFromString(int columnIndex) throws SQLException {
         var value = resultSet.getString(columnIndex);
         if (value == null) {
@@ -282,7 +286,9 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public UUID getUuidFromBytes(int columnIndex) throws SQLException {
         return UUIDConverter.convert(resultSet.getBytes(columnIndex));
     }
@@ -314,7 +320,9 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public LocalDate getLocalDate(int columnIndex) throws SQLException {
         var date = getDate(columnIndex);
         return date == null ? null : date.toLocalDate();
@@ -331,7 +339,9 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public Time getTime(int columnIndex) throws SQLException {
         return resultSet.getTime(columnIndex);
     }
@@ -347,7 +357,9 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public LocalTime getLocalTime(int columnIndex) throws SQLException {
         var time = getTime(columnIndex);
         return time != null ? time.toLocalTime() : null;
@@ -380,7 +392,9 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public LocalDateTime getLocalDateTime(int columnIndex) throws SQLException {
         Timestamp timestamp = getTimestamp(columnIndex);
         return timestamp == null ? null : timestamp.toLocalDateTime();
@@ -397,10 +411,12 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public ZonedDateTime getZonedDateTime(int columnIndex) throws SQLException {
-        LocalDateTime localDateTime = getLocalDateTime(columnIndex);
-        return localDateTime == null ? null : ZonedDateTime.from(localDateTime);
+        var timestamp = getTimestamp(columnIndex);
+        return timestamp == null ? null : timestamp.toInstant().atZone(ZoneId.systemDefault());
     }
 
     /**
@@ -414,7 +430,9 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public OffsetDateTime getOffsetDateTime(int columnIndex) throws SQLException {
         LocalDateTime localDateTime = getLocalDateTime(columnIndex);
         return localDateTime == null ? null : OffsetDateTime.from(localDateTime);
@@ -431,7 +449,9 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public OffsetTime getOffsetTime(int columnIndex) throws SQLException {
         LocalTime localDateTime = getLocalTime(columnIndex);
         return localDateTime == null ? null : OffsetTime.from(localDateTime);
@@ -545,7 +565,9 @@ public class Row {
      * @throws SQLException if the columnLabel is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public UUID getUuidFromString(String columnLabel) throws SQLException {
         var value = resultSet.getString(columnAlias(columnLabel));
         if (value == null) {
@@ -701,7 +723,9 @@ public class Row {
      * @throws SQLException if the columnLabel is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public UUID getUuidFromBytes(String columnLabel) throws SQLException {
         return UUIDConverter.convert(resultSet.getBytes(columnAlias(columnLabel)));
     }
@@ -766,7 +790,9 @@ public class Row {
      * @throws SQLException if the columnLabel is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public LocalDate getLocalDate(String columnLabel) throws SQLException {
         var date = getDate(columnLabel);
         return date == null ? null : date.toLocalDate();
@@ -801,7 +827,9 @@ public class Row {
      * @throws SQLException if the columnLabel is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public LocalTime getLocalTime(String columnLabel) throws SQLException {
         var time = getTime(columnLabel);
         return time != null ? time.toLocalTime() : null;
@@ -834,7 +862,9 @@ public class Row {
      * @throws SQLException if the columnLabel is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public LocalDateTime getLocalDateTime(String columnLabel) throws SQLException {
         Timestamp timestamp = getTimestamp(columnLabel);
         return timestamp == null ? null : timestamp.toLocalDateTime();
@@ -851,10 +881,12 @@ public class Row {
      * @throws SQLException if the columnLabel is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public ZonedDateTime getZonedDateTime(String columnLabel) throws SQLException {
-        LocalDateTime localDateTime = getLocalDateTime(columnLabel);
-        return localDateTime == null ? null : ZonedDateTime.from(localDateTime);
+        var timestamp = getTimestamp(columnLabel);
+        return timestamp == null ? null : timestamp.toInstant().atZone(ZoneId.systemDefault());
     }
 
     /**
@@ -868,10 +900,12 @@ public class Row {
      * @throws SQLException if the columnLabel is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public OffsetDateTime getOffsetDateTime(String columnLabel) throws SQLException {
-        LocalDateTime localDateTime = getLocalDateTime(columnLabel);
-        return localDateTime == null ? null : OffsetDateTime.from(localDateTime);
+        var localDateTime = getTimestamp(columnLabel);
+        return localDateTime == null ? null : OffsetDateTime.from(localDateTime.toInstant());
     }
 
     /**
@@ -885,7 +919,9 @@ public class Row {
      * @throws SQLException if the columnLabel is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public OffsetTime getOffsetTime(String columnLabel) throws SQLException {
         LocalTime localDateTime = getLocalTime(columnLabel);
         return localDateTime == null ? null : OffsetTime.from(localDateTime);
@@ -1332,7 +1368,9 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs
      *                      or this method is called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public LocalDate getLocalDate(int columnIndex, Calendar cal) throws SQLException {
         var date = getDate(columnIndex, cal);
         return date == null ? null : date.toLocalDate();
@@ -1377,7 +1415,9 @@ public class Row {
      * @throws SQLException if the columnLabel is not valid;
      *                      if a database access error occurs
      *                      or this method is called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public LocalDate getLocalDate(String columnLabel, Calendar cal) throws SQLException {
         var date = getDate(columnLabel, cal);
         return date == null ? null : date.toLocalDate();
@@ -1422,7 +1462,9 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs
      *                      or this method is called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public LocalTime getLocalTime(int columnIndex, Calendar cal) throws SQLException {
         var time = getTime(columnIndex, cal);
         return time != null ? time.toLocalTime() : null;
@@ -1468,7 +1510,9 @@ public class Row {
      * @throws SQLException if the columnLabel is not valid;
      *                      if a database access error occurs
      *                      or this method is called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public LocalTime getLocalTime(String columnLabel, Calendar cal) throws SQLException {
         var time = getTime(columnLabel, cal);
         return time != null ? time.toLocalTime() : null;
@@ -1536,7 +1580,9 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs
      *                      or this method is called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public LocalDateTime getLocalDateTime(int columnIndex, Calendar cal) throws SQLException {
         Timestamp timestamp = getTimestamp(columnIndex, cal);
         return timestamp == null ? null : timestamp.toLocalDateTime();
@@ -1560,7 +1606,9 @@ public class Row {
      * @throws SQLException if the columnLabel is not valid or
      *                      if a database access error occurs
      *                      or this method is called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public LocalDateTime getLocalDateTime(String columnLabel, Calendar cal) throws SQLException {
         Timestamp timestamp = getTimestamp(columnLabel, cal);
         return timestamp == null ? null : timestamp.toLocalDateTime();
@@ -1583,10 +1631,12 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs
      *                      or this method is called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public ZonedDateTime getZonedDateTime(int columnIndex, Calendar cal) throws SQLException {
-        LocalDateTime localDateTime = getLocalDateTime(columnIndex, cal);
-        return localDateTime == null ? null : ZonedDateTime.from(localDateTime);
+        var timestamp = getTimestamp(columnIndex, cal);
+        return timestamp == null ? null : timestamp.toInstant().atZone(ZoneId.systemDefault());
     }
 
     /**
@@ -1606,10 +1656,12 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs
      *                      or this method is called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public ZonedDateTime getZonedDateTime(String columnLabel, Calendar cal) throws SQLException {
-        LocalDateTime localDateTime = getLocalDateTime(columnLabel, cal);
-        return localDateTime == null ? null : ZonedDateTime.from(localDateTime);
+        var timestamp = getTimestamp(columnLabel, cal);
+        return timestamp == null ? null : timestamp.toInstant().atZone(ZoneId.systemDefault());
     }
 
     /**
@@ -1630,6 +1682,7 @@ public class Row {
      *                      if a database access error occurs
      *                      or this method is called on a closed result set
      */
+    @Deprecated
     public OffsetDateTime getOffsetDateTime(int columnIndex, Calendar cal) throws SQLException {
         LocalDateTime localDateTime = getLocalDateTime(columnIndex, cal);
         return localDateTime == null ? null : OffsetDateTime.from(localDateTime);
@@ -1652,7 +1705,9 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs
      *                      or this method is called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public OffsetDateTime getOffsetDateTime(String columnLabel, Calendar cal) throws SQLException {
         LocalDateTime localDateTime = getLocalDateTime(columnLabel, cal);
         return localDateTime == null ? null : OffsetDateTime.from(localDateTime);
@@ -1675,7 +1730,9 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs
      *                      or this method is called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public OffsetTime getOffsetTime(int columnIndex, Calendar cal) throws SQLException {
         LocalTime localDateTime = getLocalTime(columnIndex, cal);
         return localDateTime == null ? null : OffsetTime.from(localDateTime);
@@ -1698,7 +1755,9 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs
      *                      or this method is called on a closed result set
+     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
+    @Deprecated
     public OffsetTime getOffsetTime(String columnLabel, Calendar cal) throws SQLException {
         LocalTime localDateTime = getLocalTime(columnLabel, cal);
         return localDateTime == null ? null : OffsetTime.from(localDateTime);
@@ -1998,11 +2057,39 @@ public class Row {
         return resultSet.getObject(columnAlias(columnLabel), type);
     }
 
+    /**
+     * Retrieves the value of the designated column in the current row
+     * of this {@code Row} object and will convert from the
+     * SQL type of the column to the java type using the provided {@link ValueReader}
+     *
+     * @param columnLabel label of the column
+     * @param reader      Reader instance
+     * @param <V>         The sql type that is read from the result set
+     * @param <T>         The java type the reader returns after parsing
+     * @return An object of the requested type or null if the object is null
+     * @throws SQLException if the value can not be converted
+     */
     public <V, T> T get(String columnLabel, ValueReader<V, T> reader) throws SQLException {
-        return reader.parse(reader.namedReader().apply(this, columnAlias(columnLabel)));
+        V value = reader.namedReader().apply(this, columnAlias(columnLabel));
+        if (value == null) return null;
+        return reader.parse(value);
     }
-    public <V, T> T get(int columnLabel, ValueReader<V, T> reader) throws SQLException {
-        return reader.parse(reader.indexedReader().apply(this, columnLabel));
+
+    /**
+     * Retrieves the value of the designated column in the current row
+     * of this {@code Row} object and will convert from the
+     * SQL type of the column to the java type using the provided {@link ValueReader}
+     *
+     * @param index  index of the column
+     * @param reader Reader instance
+     * @param <V>    The sql type that is read from the result set
+     * @param <T>    The java type the reader returns after parsing
+     * @return An object of the requested type or null if the object is null
+     * @throws SQLException if the value can not be converted
+     */
+    public <V, T> T get(int index, ValueReader<V, T> reader) throws SQLException {
+        V value = reader.indexedReader().apply(this, index);
+        return reader.parse(value);
     }
 
     private String columnAlias(String columnLabel) {

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/wrapper/Row.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/wrapper/Row.java
@@ -121,11 +121,7 @@ public class Row {
      * @since 1.2
      */
     public <T extends Enum<T>> T getEnum(int columnIndex, Class<T> clazz) throws SQLException {
-        var value = getString(columnIndex);
-        if (value == null) {
-            return null;
-        }
-        return Enum.valueOf(clazz, value);
+        return get(columnIndex, StandardReader.forEnum(clazz));
     }
 
     /**

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/wrapper/Row.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/wrapper/Row.java
@@ -7,7 +7,6 @@
 package de.chojo.sadu.mapper.wrapper;
 
 import de.chojo.sadu.core.conversion.ArrayConverter;
-import de.chojo.sadu.core.conversion.UUIDConverter;
 import de.chojo.sadu.mapper.MapperConfig;
 import de.chojo.sadu.mapper.reader.StandardReader;
 import de.chojo.sadu.mapper.reader.ValueReader;
@@ -36,12 +35,26 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import static de.chojo.sadu.mapper.reader.StandardReader.LOCAL_DATE;
+import static de.chojo.sadu.mapper.reader.StandardReader.LOCAL_DATE_TIME;
+import static de.chojo.sadu.mapper.reader.StandardReader.LOCAL_TIME;
+import static de.chojo.sadu.mapper.reader.StandardReader.OFFSET_DATE_TIME;
+import static de.chojo.sadu.mapper.reader.StandardReader.OFFSET_TIME;
+import static de.chojo.sadu.mapper.reader.StandardReader.UUID_FROM_BYTES;
+import static de.chojo.sadu.mapper.reader.StandardReader.UUID_FROM_STRING;
+import static de.chojo.sadu.mapper.reader.StandardReader.ZONED_DATE_TIME;
+import static de.chojo.sadu.mapper.reader.StandardReader.localDate;
+import static de.chojo.sadu.mapper.reader.StandardReader.localDateTime;
+import static de.chojo.sadu.mapper.reader.StandardReader.localTime;
+import static de.chojo.sadu.mapper.reader.StandardReader.offsetDateTime;
+import static de.chojo.sadu.mapper.reader.StandardReader.offsetTime;
+import static de.chojo.sadu.mapper.reader.StandardReader.zonedDateTime;
 
 /**
  * Represents the row of a result set. Made to restrict actions on valid calls.
@@ -132,11 +145,7 @@ public class Row {
      */
     @Deprecated
     public UUID getUuidFromString(int columnIndex) throws SQLException {
-        var value = resultSet.getString(columnIndex);
-        if (value == null) {
-            return null;
-        }
-        return UUID.fromString(value);
+        return get(columnIndex, StandardReader.UUID_FROM_STRING);
     }
 
     /**
@@ -290,7 +299,7 @@ public class Row {
      */
     @Deprecated
     public UUID getUuidFromBytes(int columnIndex) throws SQLException {
-        return UUIDConverter.convert(resultSet.getBytes(columnIndex));
+        return get(columnIndex, UUID_FROM_BYTES);
     }
 
     /**
@@ -324,8 +333,7 @@ public class Row {
      */
     @Deprecated
     public LocalDate getLocalDate(int columnIndex) throws SQLException {
-        var date = getDate(columnIndex);
-        return date == null ? null : date.toLocalDate();
+        return get(columnIndex, LOCAL_DATE);
     }
 
     /**
@@ -339,9 +347,7 @@ public class Row {
      * @throws SQLException if the columnIndex is not valid;
      *                      if a database access error occurs or this method is
      *                      called on a closed result set
-     * @deprecated Use {@link #get(String, ValueReader)} with one of the {@link StandardReader}
      */
-    @Deprecated
     public Time getTime(int columnIndex) throws SQLException {
         return resultSet.getTime(columnIndex);
     }
@@ -361,8 +367,7 @@ public class Row {
      */
     @Deprecated
     public LocalTime getLocalTime(int columnIndex) throws SQLException {
-        var time = getTime(columnIndex);
-        return time != null ? time.toLocalTime() : null;
+        return get(columnIndex, LOCAL_TIME);
     }
 
     /**
@@ -396,8 +401,7 @@ public class Row {
      */
     @Deprecated
     public LocalDateTime getLocalDateTime(int columnIndex) throws SQLException {
-        Timestamp timestamp = getTimestamp(columnIndex);
-        return timestamp == null ? null : timestamp.toLocalDateTime();
+        return get(columnIndex, LOCAL_DATE_TIME);
     }
 
     /**
@@ -415,8 +419,7 @@ public class Row {
      */
     @Deprecated
     public ZonedDateTime getZonedDateTime(int columnIndex) throws SQLException {
-        var timestamp = getTimestamp(columnIndex);
-        return timestamp == null ? null : timestamp.toInstant().atZone(ZoneId.systemDefault());
+        return get(columnIndex, ZONED_DATE_TIME);
     }
 
     /**
@@ -434,8 +437,7 @@ public class Row {
      */
     @Deprecated
     public OffsetDateTime getOffsetDateTime(int columnIndex) throws SQLException {
-        LocalDateTime localDateTime = getLocalDateTime(columnIndex);
-        return localDateTime == null ? null : OffsetDateTime.from(localDateTime);
+        return get(columnIndex, OFFSET_DATE_TIME);
     }
 
     /**
@@ -453,8 +455,7 @@ public class Row {
      */
     @Deprecated
     public OffsetTime getOffsetTime(int columnIndex) throws SQLException {
-        LocalTime localDateTime = getLocalTime(columnIndex);
-        return localDateTime == null ? null : OffsetTime.from(localDateTime);
+        return get(columnIndex, OFFSET_TIME);
     }
 
     /**
@@ -547,11 +548,7 @@ public class Row {
      * @since 1.2
      */
     public <T extends Enum<T>> T getEnum(String columnLabel, Class<T> clazz) throws SQLException {
-        var value = getString(columnLabel);
-        if (value == null) {
-            return null;
-        }
-        return Enum.valueOf(clazz, value);
+        return get(columnLabel, StandardReader.forEnum(clazz));
     }
 
     /**
@@ -569,11 +566,7 @@ public class Row {
      */
     @Deprecated
     public UUID getUuidFromString(String columnLabel) throws SQLException {
-        var value = resultSet.getString(columnAlias(columnLabel));
-        if (value == null) {
-            return null;
-        }
-        return UUID.fromString(value);
+        return get(columnLabel, UUID_FROM_STRING);
     }
 
     /**
@@ -727,7 +720,7 @@ public class Row {
      */
     @Deprecated
     public UUID getUuidFromBytes(String columnLabel) throws SQLException {
-        return UUIDConverter.convert(resultSet.getBytes(columnAlias(columnLabel)));
+        return get(columnLabel, UUID_FROM_BYTES);
     }
 
     /**
@@ -794,8 +787,7 @@ public class Row {
      */
     @Deprecated
     public LocalDate getLocalDate(String columnLabel) throws SQLException {
-        var date = getDate(columnLabel);
-        return date == null ? null : date.toLocalDate();
+        return get(columnLabel, LOCAL_DATE);
     }
 
     /**
@@ -831,8 +823,7 @@ public class Row {
      */
     @Deprecated
     public LocalTime getLocalTime(String columnLabel) throws SQLException {
-        var time = getTime(columnLabel);
-        return time != null ? time.toLocalTime() : null;
+        return get(columnLabel, LOCAL_TIME);
     }
 
     /**
@@ -866,8 +857,7 @@ public class Row {
      */
     @Deprecated
     public LocalDateTime getLocalDateTime(String columnLabel) throws SQLException {
-        Timestamp timestamp = getTimestamp(columnLabel);
-        return timestamp == null ? null : timestamp.toLocalDateTime();
+        return get(columnLabel, LOCAL_DATE_TIME);
     }
 
     /**
@@ -885,8 +875,7 @@ public class Row {
      */
     @Deprecated
     public ZonedDateTime getZonedDateTime(String columnLabel) throws SQLException {
-        var timestamp = getTimestamp(columnLabel);
-        return timestamp == null ? null : timestamp.toInstant().atZone(ZoneId.systemDefault());
+        return get(columnLabel, ZONED_DATE_TIME);
     }
 
     /**
@@ -904,8 +893,7 @@ public class Row {
      */
     @Deprecated
     public OffsetDateTime getOffsetDateTime(String columnLabel) throws SQLException {
-        var localDateTime = getTimestamp(columnLabel);
-        return localDateTime == null ? null : OffsetDateTime.from(localDateTime.toInstant());
+        return get(columnLabel, OFFSET_DATE_TIME);
     }
 
     /**
@@ -923,8 +911,7 @@ public class Row {
      */
     @Deprecated
     public OffsetTime getOffsetTime(String columnLabel) throws SQLException {
-        LocalTime localDateTime = getLocalTime(columnLabel);
-        return localDateTime == null ? null : OffsetTime.from(localDateTime);
+        return get(columnLabel, OFFSET_TIME);
     }
 
     /**
@@ -1372,8 +1359,7 @@ public class Row {
      */
     @Deprecated
     public LocalDate getLocalDate(int columnIndex, Calendar cal) throws SQLException {
-        var date = getDate(columnIndex, cal);
-        return date == null ? null : date.toLocalDate();
+        return get(columnIndex, localDate(cal));
     }
 
     /**
@@ -1419,8 +1405,7 @@ public class Row {
      */
     @Deprecated
     public LocalDate getLocalDate(String columnLabel, Calendar cal) throws SQLException {
-        var date = getDate(columnLabel, cal);
-        return date == null ? null : date.toLocalDate();
+        return get(columnLabel, localDate(cal));
     }
 
     /**
@@ -1466,8 +1451,7 @@ public class Row {
      */
     @Deprecated
     public LocalTime getLocalTime(int columnIndex, Calendar cal) throws SQLException {
-        var time = getTime(columnIndex, cal);
-        return time != null ? time.toLocalTime() : null;
+        return get(columnIndex, localTime(cal));
     }
 
 
@@ -1514,8 +1498,7 @@ public class Row {
      */
     @Deprecated
     public LocalTime getLocalTime(String columnLabel, Calendar cal) throws SQLException {
-        var time = getTime(columnLabel, cal);
-        return time != null ? time.toLocalTime() : null;
+        return get(columnLabel, localTime(cal));
     }
 
     /**
@@ -1584,8 +1567,7 @@ public class Row {
      */
     @Deprecated
     public LocalDateTime getLocalDateTime(int columnIndex, Calendar cal) throws SQLException {
-        Timestamp timestamp = getTimestamp(columnIndex, cal);
-        return timestamp == null ? null : timestamp.toLocalDateTime();
+        return get(columnIndex, localDateTime(cal));
     }
 
 
@@ -1610,8 +1592,7 @@ public class Row {
      */
     @Deprecated
     public LocalDateTime getLocalDateTime(String columnLabel, Calendar cal) throws SQLException {
-        Timestamp timestamp = getTimestamp(columnLabel, cal);
-        return timestamp == null ? null : timestamp.toLocalDateTime();
+        return get(columnLabel, localDateTime(cal));
     }
 
     /**
@@ -1635,8 +1616,7 @@ public class Row {
      */
     @Deprecated
     public ZonedDateTime getZonedDateTime(int columnIndex, Calendar cal) throws SQLException {
-        var timestamp = getTimestamp(columnIndex, cal);
-        return timestamp == null ? null : timestamp.toInstant().atZone(ZoneId.systemDefault());
+        return get(columnIndex, zonedDateTime(cal));
     }
 
     /**
@@ -1660,8 +1640,7 @@ public class Row {
      */
     @Deprecated
     public ZonedDateTime getZonedDateTime(String columnLabel, Calendar cal) throws SQLException {
-        var timestamp = getTimestamp(columnLabel, cal);
-        return timestamp == null ? null : timestamp.toInstant().atZone(ZoneId.systemDefault());
+        return get(columnLabel, zonedDateTime(cal));
     }
 
     /**
@@ -1684,8 +1663,7 @@ public class Row {
      */
     @Deprecated
     public OffsetDateTime getOffsetDateTime(int columnIndex, Calendar cal) throws SQLException {
-        LocalDateTime localDateTime = getLocalDateTime(columnIndex, cal);
-        return localDateTime == null ? null : OffsetDateTime.from(localDateTime);
+        return get(columnIndex, offsetDateTime(cal));
     }
 
     /**
@@ -1709,8 +1687,7 @@ public class Row {
      */
     @Deprecated
     public OffsetDateTime getOffsetDateTime(String columnLabel, Calendar cal) throws SQLException {
-        LocalDateTime localDateTime = getLocalDateTime(columnLabel, cal);
-        return localDateTime == null ? null : OffsetDateTime.from(localDateTime);
+        return get(columnLabel, offsetDateTime(cal));
     }
 
     /**
@@ -1734,8 +1711,7 @@ public class Row {
      */
     @Deprecated
     public OffsetTime getOffsetTime(int columnIndex, Calendar cal) throws SQLException {
-        LocalTime localDateTime = getLocalTime(columnIndex, cal);
-        return localDateTime == null ? null : OffsetTime.from(localDateTime);
+        return get(columnIndex, offsetTime(cal));
     }
 
     /**
@@ -1759,8 +1735,7 @@ public class Row {
      */
     @Deprecated
     public OffsetTime getOffsetTime(String columnLabel, Calendar cal) throws SQLException {
-        LocalTime localDateTime = getLocalTime(columnLabel, cal);
-        return localDateTime == null ? null : OffsetTime.from(localDateTime);
+        return get(columnLabel, offsetTime(cal));
     }
 
     /**
@@ -2089,6 +2064,7 @@ public class Row {
      */
     public <V, T> T get(int index, ValueReader<V, T> reader) throws SQLException {
         V value = reader.indexedReader().apply(this, index);
+        if (value == null) return null;
         return reader.parser().apply(value);
     }
 

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/wrapper/Row.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/wrapper/Row.java
@@ -2040,10 +2040,10 @@ public class Row {
      * @return An object of the requested type or null if the object is null
      * @throws SQLException if the value can not be converted
      */
-    public <V, T> T get(String columnLabel, ValueReader<V, T> reader) throws SQLException {
+    public <V, T> T get(String columnLabel, ValueReader<T, V> reader) throws SQLException {
         V value = reader.namedReader().apply(this, columnAlias(columnLabel));
         if (value == null) return null;
-        return reader.parser().apply(value);
+        return reader.reader().apply(value);
     }
 
     /**
@@ -2058,10 +2058,10 @@ public class Row {
      * @return An object of the requested type or null if the object is null
      * @throws SQLException if the value can not be converted
      */
-    public <V, T> T get(int index, ValueReader<V, T> reader) throws SQLException {
+    public <V, T> T get(int index, ValueReader<T, V> reader) throws SQLException {
         V value = reader.indexedReader().apply(this, index);
         if (value == null) return null;
-        return reader.parser().apply(value);
+        return reader.reader().apply(value);
     }
 
     private String columnAlias(String columnLabel) {

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/wrapper/Row.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/wrapper/Row.java
@@ -9,6 +9,7 @@ package de.chojo.sadu.mapper.wrapper;
 import de.chojo.sadu.core.conversion.ArrayConverter;
 import de.chojo.sadu.core.conversion.UUIDConverter;
 import de.chojo.sadu.mapper.MapperConfig;
+import de.chojo.sadu.mapper.reader.ValueReader;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.io.InputStream;
@@ -1995,6 +1996,13 @@ public class Row {
      */
     public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
         return resultSet.getObject(columnAlias(columnLabel), type);
+    }
+
+    public <V, T> T get(String columnLabel, ValueReader<V, T> reader) throws SQLException {
+        return reader.parse(reader.namedReader().apply(this, columnAlias(columnLabel)));
+    }
+    public <V, T> T get(int columnLabel, ValueReader<V, T> reader) throws SQLException {
+        return reader.parse(reader.indexedReader().apply(this, columnLabel));
     }
 
     private String columnAlias(String columnLabel) {

--- a/sadu-mapper/src/main/java/de/chojo/sadu/mapper/wrapper/Row.java
+++ b/sadu-mapper/src/main/java/de/chojo/sadu/mapper/wrapper/Row.java
@@ -2042,7 +2042,7 @@ public class Row {
      */
     public <V, T> T get(String columnLabel, ValueReader<T, V> reader) throws SQLException {
         V value = reader.namedReader().apply(this, columnAlias(columnLabel));
-        if (value == null) return null;
+        if (value == null) return reader.defaultValue();
         return reader.reader().apply(value);
     }
 
@@ -2060,7 +2060,7 @@ public class Row {
      */
     public <V, T> T get(int index, ValueReader<T, V> reader) throws SQLException {
         V value = reader.indexedReader().apply(this, index);
-        if (value == null) return null;
+        if (value == null) return reader.defaultValue();
         return reader.reader().apply(value);
     }
 

--- a/sadu-mapper/src/main/java/module-info.java
+++ b/sadu-mapper/src/main/java/module-info.java
@@ -2,6 +2,7 @@ module sadu.sadu.mapper.main {
     requires transitive sadu.sadu.core.main;
 
     exports de.chojo.sadu.mapper;
+    exports de.chojo.sadu.mapper.reader;
     exports de.chojo.sadu.mapper.exceptions;
     exports de.chojo.sadu.mapper.rowmapper;
     exports de.chojo.sadu.mapper.util;

--- a/sadu-queries/src/main/java/de/chojo/sadu/queries/api/call/adapter/Adapter.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/queries/api/call/adapter/Adapter.java
@@ -14,6 +14,7 @@ import java.util.function.Function;
  * The Adapter interface provides a way to map Java objects to a specific SQL data type and perform the necessary conversions when binding the objects to a PreparedStatement.
  *
  * @param <T> the type of object to be adapted
+ * @see de.chojo.sadu.queries.call.adapter.StandardAdapter
  */
 public interface Adapter<T> {
     /**

--- a/sadu-queries/src/main/java/de/chojo/sadu/queries/call/adapter/StandardAdapter.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/queries/call/adapter/StandardAdapter.java
@@ -53,8 +53,14 @@ public final class StandardAdapter {
     public static final Adapter<LocalTime> LOCAL_TIME = Adapter.create(PreparedStatement::setTime, Types.TIME, Time::valueOf);
     public static final Adapter<Timestamp> TIMESTAMP = Adapter.create(PreparedStatement::setTimestamp, Types.TIMESTAMP);
     public static final Adapter<LocalDateTime> LOCAL_DATE_TIME = Adapter.create(PreparedStatement::setTimestamp, Types.TIMESTAMP, Timestamp::valueOf);
-    public static final Adapter<ZonedDateTime> ZONED_DATE_TIME = Adapter.create(PreparedStatement::setTimestamp, Types.TIMESTAMP, v -> Timestamp.valueOf(v.toLocalDateTime()));
-    public static final Adapter<OffsetDateTime> OFFSET_DATE_TIME = Adapter.create(PreparedStatement::setTimestamp, Types.TIMESTAMP, v -> Timestamp.valueOf(v.toLocalDateTime()));
+    /**
+     * Writes a zoned date time after converting it to an {@link Instant} storing it in UTC
+     */
+    public static final Adapter<ZonedDateTime> ZONED_DATE_TIME = Adapter.create(PreparedStatement::setTimestamp, Types.TIMESTAMP, v -> Timestamp.from(v.toInstant()));
+    /**
+     * Writes an offset date time after converting it to an {@link Instant} storing it in UTC
+     */
+    public static final Adapter<OffsetDateTime> OFFSET_DATE_TIME = Adapter.create(PreparedStatement::setTimestamp, Types.TIMESTAMP, v -> Timestamp.from(v.toInstant()));
     public static final Adapter<OffsetTime> OFFSET_TIME = Adapter.create(PreparedStatement::setTime, Types.TIME, v -> Time.valueOf(v.toLocalTime()));
     /**
      * Stores an instant as a timestamp

--- a/sadu-queries/src/main/java/de/chojo/sadu/queries/call/adapter/StandardAdapter.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/queries/call/adapter/StandardAdapter.java
@@ -20,6 +20,7 @@ import java.sql.RowId;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -55,6 +56,18 @@ public final class StandardAdapter {
     public static final Adapter<ZonedDateTime> ZONED_DATE_TIME = Adapter.create(PreparedStatement::setTimestamp, Types.TIMESTAMP, v -> Timestamp.valueOf(v.toLocalDateTime()));
     public static final Adapter<OffsetDateTime> OFFSET_DATE_TIME = Adapter.create(PreparedStatement::setTimestamp, Types.TIMESTAMP, v -> Timestamp.valueOf(v.toLocalDateTime()));
     public static final Adapter<OffsetTime> OFFSET_TIME = Adapter.create(PreparedStatement::setTime, Types.TIME, v -> Time.valueOf(v.toLocalTime()));
+    /**
+     * Stores an instant as a timestamp
+     */
+    public static final Adapter<Instant> INSTANT = Adapter.create(PreparedStatement::setTimestamp, Types.TIMESTAMP, Timestamp::from);
+    /**
+     * Stores an instant as epoch millis
+     */
+    public static final Adapter<Instant> INSTANT_AS_MILLIS = Adapter.create(PreparedStatement::setLong, Types.BIGINT, Instant::toEpochMilli);
+    /**
+     * Stores an instant as epoch seconds
+     */
+    public static final Adapter<Instant> INSTANT_AS_SECONDS = Adapter.create(PreparedStatement::setLong, Types.BIGINT, Instant::getEpochSecond);
     public static final Adapter<Ref> REF = Adapter.create(PreparedStatement::setRef, Types.REF);
     public static final Adapter<Blob> BLOB = Adapter.create(PreparedStatement::setBlob, Types.BLOB);
     public static final Adapter<Clob> CLOB = Adapter.create(PreparedStatement::setClob, Types.CLOB);

--- a/sadu-queries/src/main/java/de/chojo/sadu/queries/call/adapter/StandardAdapter.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/queries/call/adapter/StandardAdapter.java
@@ -59,7 +59,7 @@ public final class StandardAdapter {
     /**
      * Stores an instant as a timestamp
      */
-    public static final Adapter<Instant> INSTANT = Adapter.create(PreparedStatement::setTimestamp, Types.TIMESTAMP, Timestamp::from);
+    public static final Adapter<Instant> INSTANT_AS_TIMESTAMP = Adapter.create(PreparedStatement::setTimestamp, Types.TIMESTAMP, Timestamp::from);
     /**
      * Stores an instant as epoch millis
      */

--- a/sadu-queries/src/main/java/de/chojo/sadu/queries/call/adapter/StandardAdapter.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/queries/call/adapter/StandardAdapter.java
@@ -8,6 +8,9 @@ package de.chojo.sadu.queries.call.adapter;
 
 import de.chojo.sadu.core.types.SqlType;
 import de.chojo.sadu.queries.api.call.adapter.Adapter;
+import de.chojo.sadu.queries.converter.StandardValueConverter;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 import java.math.BigDecimal;
 import java.net.URL;
@@ -35,6 +38,8 @@ import static de.chojo.sadu.core.conversion.ArrayConverter.toSqlArray;
 /**
  * The StandardAdapter class provides a set of static instances of Adapter, which map Java objects to specific SQL data types and provide the necessary conversions when binding the
  * objects to a PreparedStatement.
+ *
+ * @see StandardValueConverter
  */
 public final class StandardAdapter {
     public static final Adapter<String> STRING = Adapter.create(PreparedStatement::setString, Types.VARCHAR);
@@ -85,35 +90,43 @@ public final class StandardAdapter {
         throw new UnsupportedOperationException("This is a utility class.");
     }
 
-    public static Adapter<Collection<?>> forCollection(Collection<?> list, SqlType type) {
+    @Contract(value = "_, _ -> new", pure = true)
+    public static @NotNull Adapter<Collection<?>> forCollection(Collection<?> list, SqlType type) {
         return Adapter.create((stmt, index, value) -> stmt.setArray(index, toSqlArray(stmt.getConnection(), type, list)), Types.ARRAY);
     }
 
-    public static Adapter<Object[]> forArray(Object[] array, SqlType type) {
+    @Contract(value = "_, _ -> new", pure = true)
+    public static @NotNull Adapter<Object[]> forArray(Object[] array, SqlType type) {
         return Adapter.create((stmt, index, value) -> stmt.setArray(index, toSqlArray(stmt.getConnection(), type, array)), Types.ARRAY);
     }
 
-    public static Adapter<LocalDate> localDate(Calendar calendar) {
+    @Contract(value = "_ -> new", pure = true)
+    public static @NotNull Adapter<LocalDate> localDate(Calendar calendar) {
         return Adapter.create((stmt, index, value) -> stmt.setDate(index, value, calendar), Types.DATE, Date::valueOf);
     }
 
-    public static Adapter<LocalTime> localTime(Calendar calendar) {
+    @Contract(value = "_ -> new", pure = true)
+    public static @NotNull Adapter<LocalTime> localTime(Calendar calendar) {
         return Adapter.create((stmt, index, value) -> stmt.setTime(index, value, calendar), Types.TIME, Time::valueOf);
     }
 
-    public static Adapter<OffsetTime> offsetTime(Calendar calendar) {
+    @Contract(value = "_ -> new", pure = true)
+    public static @NotNull Adapter<OffsetTime> offsetTime(Calendar calendar) {
         return Adapter.create((stmt, index, value) -> stmt.setTime(index, value, calendar), Types.TIME, v -> Time.valueOf(v.toLocalTime()));
     }
 
-    public static Adapter<LocalDateTime> localDateTime(Calendar calendar) {
+    @Contract(value = "_ -> new", pure = true)
+    public static @NotNull Adapter<LocalDateTime> localDateTime(Calendar calendar) {
         return Adapter.create((stmt, index, value) -> stmt.setTimestamp(index, value, calendar), Types.TIMESTAMP, Timestamp::valueOf);
     }
 
-    public static Adapter<OffsetDateTime> offsetDateTime(Calendar calendar) {
+    @Contract(value = "_ -> new", pure = true)
+    public static @NotNull Adapter<OffsetDateTime> offsetDateTime(Calendar calendar) {
         return Adapter.create((stmt, index, value) -> stmt.setTimestamp(index, value, calendar), Types.TIMESTAMP, v -> Timestamp.from(v.toInstant()));
     }
 
-    public static Adapter<ZonedDateTime> zonedDateTime(Calendar calendar) {
+    @Contract(value = "_ -> new", pure = true)
+    public static @NotNull Adapter<ZonedDateTime> zonedDateTime(Calendar calendar) {
         return Adapter.create((stmt, index, value) -> stmt.setTimestamp(index, value, calendar), Types.TIMESTAMP, v -> Timestamp.from(v.toInstant()));
     }
 }

--- a/sadu-queries/src/main/java/de/chojo/sadu/queries/call/adapter/StandardAdapter.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/queries/call/adapter/StandardAdapter.java
@@ -27,6 +27,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZonedDateTime;
+import java.util.Calendar;
 import java.util.Collection;
 
 import static de.chojo.sadu.core.conversion.ArrayConverter.toSqlArray;
@@ -90,5 +91,29 @@ public final class StandardAdapter {
 
     public static Adapter<Object[]> forArray(Object[] array, SqlType type) {
         return Adapter.create((stmt, index, value) -> stmt.setArray(index, toSqlArray(stmt.getConnection(), type, array)), Types.ARRAY);
+    }
+
+    public static Adapter<LocalDate> localDate(Calendar calendar) {
+        return Adapter.create((stmt, index, value) -> stmt.setDate(index, value, calendar), Types.DATE, Date::valueOf);
+    }
+
+    public static Adapter<LocalTime> localTime(Calendar calendar) {
+        return Adapter.create((stmt, index, value) -> stmt.setTime(index, value, calendar), Types.TIME, Time::valueOf);
+    }
+
+    public static Adapter<OffsetTime> offsetTime(Calendar calendar) {
+        return Adapter.create((stmt, index, value) -> stmt.setTime(index, value, calendar), Types.TIME, v -> Time.valueOf(v.toLocalTime()));
+    }
+
+    public static Adapter<LocalDateTime> localDateTime(Calendar calendar) {
+        return Adapter.create((stmt, index, value) -> stmt.setTimestamp(index, value, calendar), Types.TIMESTAMP, Timestamp::valueOf);
+    }
+
+    public static Adapter<OffsetDateTime> offsetDateTime(Calendar calendar) {
+        return Adapter.create((stmt, index, value) -> stmt.setTimestamp(index, value, calendar), Types.TIMESTAMP, v -> Timestamp.from(v.toInstant()));
+    }
+
+    public static Adapter<ZonedDateTime> zonedDateTime(Calendar calendar) {
+        return Adapter.create((stmt, index, value) -> stmt.setTimestamp(index, value, calendar), Types.TIMESTAMP, v -> Timestamp.from(v.toInstant()));
     }
 }

--- a/sadu-queries/src/main/java/de/chojo/sadu/queries/converter/StandardValueConverter.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/queries/converter/StandardValueConverter.java
@@ -1,0 +1,66 @@
+package de.chojo.sadu.queries.converter;
+
+import de.chojo.sadu.mapper.reader.StandardReader;
+import de.chojo.sadu.queries.api.call.adapter.Adapter;
+import de.chojo.sadu.queries.call.adapter.StandardAdapter;
+import de.chojo.sadu.queries.call.adapter.UUIDAdapter;
+
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.UUID;
+
+import static de.chojo.sadu.queries.converter.ValueConverter.create;
+
+public final class StandardValueConverter {
+    public static final ValueConverter<Instant, Long> INSTANT_MILLIS = create(StandardAdapter.INSTANT_AS_MILLIS, StandardReader.INSTANT_FROM_MILLIS);
+    public static final ValueConverter<Instant, Long> INSTANT_SECONDS = create(StandardAdapter.INSTANT_AS_SECONDS, StandardReader.INSTANT_FROM_SECONDS);
+    public static final ValueConverter<Instant, Timestamp> INSTANT_TIMESTAMP = create(StandardAdapter.INSTANT_AS_TIMESTAMP, StandardReader.INSTANT_FROM_TIMESTAMP);
+    public static final ValueConverter<LocalDateTime, Timestamp> LOCAL_DATE_TIME = create(StandardAdapter.LOCAL_DATE_TIME, StandardReader.LOCAL_DATE_TIME);
+    public static final ValueConverter<OffsetDateTime, Timestamp> OFFSET_DATE_TIME = create(StandardAdapter.OFFSET_DATE_TIME, StandardReader.OFFSET_DATE_TIME);
+    public static final ValueConverter<ZonedDateTime, Timestamp> ZONED_DATE_TIME = create(StandardAdapter.ZONED_DATE_TIME, StandardReader.ZONED_DATE_TIME);
+    public static final ValueConverter<OffsetTime, Time> OFFSET_TIME = create(StandardAdapter.OFFSET_TIME, StandardReader.OFFSET_TIME);
+    public static final ValueConverter<LocalDate, Date> LOCAL_DATE = create(StandardAdapter.LOCAL_DATE, StandardReader.LOCAL_DATE);
+    public static final ValueConverter<LocalTime, Time> LOCAL_TIME = create(StandardAdapter.LOCAL_TIME, StandardReader.LOCAL_TIME);
+    public static final ValueConverter<UUID, String> UUID_STRING = create(UUIDAdapter.AS_STRING, StandardReader.UUID_FROM_STRING);
+    public static final ValueConverter<UUID, byte[]> UUID_BYTES = create(UUIDAdapter.AS_BYTES, StandardReader.UUID_FROM_BYTES);
+
+    public static <T extends Enum<T>> ValueConverter<T, String> forEnum(Class<T> clazz) {
+        // Normally an explicit type isn't required to write an enum, but in this case we need it.
+        return create(Adapter.create(PreparedStatement::setString, Types.VARCHAR, Enum::name), StandardReader.forEnum(clazz));
+    }
+
+    public static ValueConverter<LocalDate, Date> localDate(Calendar calendar) {
+        return create(StandardAdapter.localDate(calendar), StandardReader.localDate(calendar));
+    }
+
+    public static ValueConverter<LocalTime, Time> localTime(Calendar calendar) {
+        return create(StandardAdapter.localTime(calendar), StandardReader.localTime(calendar));
+    }
+
+    public static ValueConverter<OffsetTime, Time> offsetTime(Calendar calendar) {
+        return create(StandardAdapter.offsetTime(calendar), StandardReader.offsetTime(calendar));
+    }
+
+    public static ValueConverter<LocalDateTime, Timestamp> localDateTime(Calendar calendar) {
+        return create(StandardAdapter.localDateTime(calendar), StandardReader.localDateTime(calendar));
+    }
+
+    public static ValueConverter<OffsetDateTime, Timestamp> offsetDateTime(Calendar calendar) {
+        return create(StandardAdapter.offsetDateTime(calendar), StandardReader.offsetDateTime(calendar));
+    }
+
+    public static ValueConverter<ZonedDateTime, Timestamp> zonedDateTime(Calendar calendar) {
+        return create(StandardAdapter.zonedDateTime(calendar), StandardReader.zonedDateTime(calendar));
+    }
+}

--- a/sadu-queries/src/main/java/de/chojo/sadu/queries/converter/StandardValueConverter.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/queries/converter/StandardValueConverter.java
@@ -4,6 +4,8 @@ import de.chojo.sadu.mapper.reader.StandardReader;
 import de.chojo.sadu.queries.api.call.adapter.Adapter;
 import de.chojo.sadu.queries.call.adapter.StandardAdapter;
 import de.chojo.sadu.queries.call.adapter.UUIDAdapter;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 import java.sql.Date;
 import java.sql.PreparedStatement;
@@ -22,45 +24,133 @@ import java.util.UUID;
 
 import static de.chojo.sadu.queries.converter.ValueConverter.create;
 
+/**
+ * The StandardValueConverter class provides a set of predefined ValueConverters for various types.
+ * Each ValueConverter maps between a Java type and an intermediate SQL type.
+ *
+ */
 public final class StandardValueConverter {
+    /**
+     * Writes and reads {@link Instant} as unix epoch in milliseconds
+     */
     public static final ValueConverter<Instant, Long> INSTANT_MILLIS = create(StandardAdapter.INSTANT_AS_MILLIS, StandardReader.INSTANT_FROM_MILLIS);
+    /**
+     * Writes and reads {@link Instant} as unix epoch in seconds
+     */
     public static final ValueConverter<Instant, Long> INSTANT_SECONDS = create(StandardAdapter.INSTANT_AS_SECONDS, StandardReader.INSTANT_FROM_SECONDS);
+    /**
+     * Writes and reads {@link Instant} as {@link Timestamp}
+     */
     public static final ValueConverter<Instant, Timestamp> INSTANT_TIMESTAMP = create(StandardAdapter.INSTANT_AS_TIMESTAMP, StandardReader.INSTANT_FROM_TIMESTAMP);
+    /**
+     * Writes and reads {@link LocalDateTime} as {@link Timestamp}
+     */
     public static final ValueConverter<LocalDateTime, Timestamp> LOCAL_DATE_TIME = create(StandardAdapter.LOCAL_DATE_TIME, StandardReader.LOCAL_DATE_TIME);
+    /**
+     * Writes and reads {@link OffsetDateTime} as {@link Timestamp}. Will be stored in UTC.
+     */
     public static final ValueConverter<OffsetDateTime, Timestamp> OFFSET_DATE_TIME = create(StandardAdapter.OFFSET_DATE_TIME, StandardReader.OFFSET_DATE_TIME);
+    /**
+     * Writes and reads {@link ZonedDateTime} as {@link Timestamp}. Will be stored in UTC.
+     */
     public static final ValueConverter<ZonedDateTime, Timestamp> ZONED_DATE_TIME = create(StandardAdapter.ZONED_DATE_TIME, StandardReader.ZONED_DATE_TIME);
+    /**
+     * Writes and reads {@link OffsetTime} as {@link Time}. Will be stored as {@link LocalTime}.
+     */
     public static final ValueConverter<OffsetTime, Time> OFFSET_TIME = create(StandardAdapter.OFFSET_TIME, StandardReader.OFFSET_TIME);
+    /**
+     * Writes and reads {@link LocalDate} as {@link Date}.
+     */
     public static final ValueConverter<LocalDate, Date> LOCAL_DATE = create(StandardAdapter.LOCAL_DATE, StandardReader.LOCAL_DATE);
+    /**
+     * Writes and reads {@link LocalTime} as {@link Time}.
+     */
     public static final ValueConverter<LocalTime, Time> LOCAL_TIME = create(StandardAdapter.LOCAL_TIME, StandardReader.LOCAL_TIME);
+    /**
+     * Writes and reads {@link UUID} as {@link String}.
+     */
     public static final ValueConverter<UUID, String> UUID_STRING = create(UUIDAdapter.AS_STRING, StandardReader.UUID_FROM_STRING);
+    /**
+     * Writes and reads {@link UUID} as {@link Byte}[].
+     */
     public static final ValueConverter<UUID, byte[]> UUID_BYTES = create(UUIDAdapter.AS_BYTES, StandardReader.UUID_FROM_BYTES);
 
-    public static <T extends Enum<T>> ValueConverter<T, String> forEnum(Class<T> clazz) {
+    /**
+     * Writes and reads {@link Enum} as {@link String}.
+     *
+     * @param clazz enum class
+     * @param <T>   enum type
+     * @return A new {@link ValueConverter} instance for that specific enum type
+     */
+    @Contract("_ -> new")
+    public static <T extends Enum<T>> @NotNull ValueConverter<T, String> forEnum(Class<T> clazz) {
         // Normally an explicit type isn't required to write an enum, but in this case we need it.
         return create(Adapter.create(PreparedStatement::setString, Types.VARCHAR, Enum::name), StandardReader.forEnum(clazz));
     }
 
-    public static ValueConverter<LocalDate, Date> localDate(Calendar calendar) {
+    /**
+     * Writes and reads {@link LocalDate} as {@link Date}.
+     *
+     * @param calendar The calendar used to construct the date
+     * @return A new {@link ValueConverter} instance using the {@link Calendar}
+     */
+    @Contract("_ -> new")
+    public static @NotNull ValueConverter<LocalDate, Date> localDate(Calendar calendar) {
         return create(StandardAdapter.localDate(calendar), StandardReader.localDate(calendar));
     }
 
-    public static ValueConverter<LocalTime, Time> localTime(Calendar calendar) {
+    /**
+     * Writes and reads {@link LocalTime} as {@link Time}.
+     *
+     * @param calendar The calendar used to construct the timestamp
+     * @return A new {@link ValueConverter} instance using the {@link Calendar}
+     */
+    @Contract("_ -> new")
+    public static @NotNull ValueConverter<LocalTime, Time> localTime(Calendar calendar) {
         return create(StandardAdapter.localTime(calendar), StandardReader.localTime(calendar));
     }
 
-    public static ValueConverter<OffsetTime, Time> offsetTime(Calendar calendar) {
+    /**
+     * Writes and reads {@link OffsetTime} as {@link Time}. Will be stored as {@link LocalTime}.
+     *
+     * @param calendar The calendar used to construct the time
+     * @return A new {@link ValueConverter} instance using the {@link Calendar}
+     */
+    @Contract("_ -> new")
+    public static @NotNull ValueConverter<OffsetTime, Time> offsetTime(Calendar calendar) {
         return create(StandardAdapter.offsetTime(calendar), StandardReader.offsetTime(calendar));
     }
 
-    public static ValueConverter<LocalDateTime, Timestamp> localDateTime(Calendar calendar) {
+    /**
+     * Writes and reads {@link LocalDateTime} as {@link Timestamp}
+     *
+     * @param calendar The calendar used to construct the timestamp
+     * @return A new {@link ValueConverter} instance using the {@link Calendar}
+     */
+    @Contract("_ -> new")
+    public static @NotNull ValueConverter<LocalDateTime, Timestamp> localDateTime(Calendar calendar) {
         return create(StandardAdapter.localDateTime(calendar), StandardReader.localDateTime(calendar));
     }
 
-    public static ValueConverter<OffsetDateTime, Timestamp> offsetDateTime(Calendar calendar) {
+    /**
+     * Writes and reads {@link ZonedDateTime} as {@link Timestamp}. Will be stored in UTC.
+     *
+     * @param calendar The calendar used to construct the timestamp
+     * @return A new {@link ValueConverter} instance using the {@link Calendar}
+     */
+    @Contract("_ -> new")
+    public static @NotNull ValueConverter<OffsetDateTime, Timestamp> offsetDateTime(Calendar calendar) {
         return create(StandardAdapter.offsetDateTime(calendar), StandardReader.offsetDateTime(calendar));
     }
 
-    public static ValueConverter<ZonedDateTime, Timestamp> zonedDateTime(Calendar calendar) {
+    /**
+     * Writes and reads {@link ZonedDateTime} as {@link Timestamp}. Will be stored in UTC.
+     *
+     * @param calendar The calendar used to construct the timestamp
+     * @return A new {@link ValueConverter} instance using the {@link Calendar}
+     */
+    @Contract("_ -> new")
+    public static @NotNull ValueConverter<ZonedDateTime, Timestamp> zonedDateTime(Calendar calendar) {
         return create(StandardAdapter.zonedDateTime(calendar), StandardReader.zonedDateTime(calendar));
     }
 }

--- a/sadu-queries/src/main/java/de/chojo/sadu/queries/converter/ValueConverter.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/queries/converter/ValueConverter.java
@@ -1,0 +1,55 @@
+package de.chojo.sadu.queries.converter;
+
+import de.chojo.sadu.core.exceptions.ThrowingBiFunction;
+import de.chojo.sadu.mapper.reader.ValueReader;
+import de.chojo.sadu.mapper.wrapper.Row;
+import de.chojo.sadu.queries.api.call.adapter.Adapter;
+import de.chojo.sadu.queries.api.call.adapter.AdapterMapping;
+import org.jetbrains.annotations.NotNull;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.function.Function;
+
+/**
+ * A value converter that serves as an {@link AdapterMapping} and {@link ValueReader}
+ * @param <T> The Java type that is handled
+ * @param <V> The intermediate SQL type that is sent to the database
+ */
+public interface ValueConverter<T, V> extends Adapter<T>, ValueReader<T, V> {
+    static <T, V> ValueConverter<T, V> create(Adapter<T> mapper, ValueReader<T, V> reader) {
+        return new ValueConverter<>() {
+
+
+            @Override
+            public Function<@NotNull V, T> reader() {
+                return reader.reader();
+            }
+
+            @Override
+            public ThrowingBiFunction<Row, String, V, SQLException> namedReader() {
+                return reader.namedReader();
+            }
+
+            @Override
+            public ThrowingBiFunction<Row, Integer, V, SQLException> indexedReader() {
+                return reader.indexedReader();
+            }
+
+            @Override
+            public AdapterMapping<T> mapping() {
+                return mapper.mapping();
+            }
+
+            @Override
+            public int type() {
+                return mapper.type();
+            }
+
+            @Override
+            public void apply(PreparedStatement stmt, int index, T value) throws SQLException {
+                mapper.apply(stmt, index, value);
+            }
+        };
+    }
+}

--- a/sadu-queries/src/main/java/de/chojo/sadu/queries/converter/ValueConverter.java
+++ b/sadu-queries/src/main/java/de/chojo/sadu/queries/converter/ValueConverter.java
@@ -19,8 +19,6 @@ import java.util.function.Function;
 public interface ValueConverter<T, V> extends Adapter<T>, ValueReader<T, V> {
     static <T, V> ValueConverter<T, V> create(Adapter<T> mapper, ValueReader<T, V> reader) {
         return new ValueConverter<>() {
-
-
             @Override
             public Function<@NotNull V, T> reader() {
                 return reader.reader();

--- a/sadu-queries/src/test/java/de/chojo/sadu/PostgresDatabase.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/PostgresDatabase.java
@@ -38,7 +38,7 @@ public class PostgresDatabase {
         return new Database(self, dc);
     }
 
-    public static record Database(GenericContainer<?> container, DataSource dataSource) {
+    public record Database(GenericContainer<?> container, DataSource dataSource) {
         public void close() {
             container.close();
         }

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/InstantTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/InstantTest.java
@@ -1,0 +1,89 @@
+/*
+ *     SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *     Copyright (C) RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.queries;
+
+import de.chojo.sadu.PostgresDatabase;
+import de.chojo.sadu.mapper.RowMapperRegistry;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
+import de.chojo.sadu.postgresql.mapper.PostgresqlMapper;
+import de.chojo.sadu.queries.api.call.Call;
+import de.chojo.sadu.queries.configuration.QueryConfiguration;
+import de.chojo.sadu.queries.configuration.QueryConfigurationBuilder;
+import de.chojo.sadu.queries.examples.dao.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.time.Instant;
+
+import static de.chojo.sadu.PostgresDatabase.createContainer;
+import static de.chojo.sadu.mapper.reader.StandardReader.INSTANT_FROM_MILLIS;
+import static de.chojo.sadu.mapper.reader.StandardReader.INSTANT_FROM_SECONDS;
+import static de.chojo.sadu.mapper.reader.StandardReader.INSTANT_FROM_TIMESTAMP;
+import static de.chojo.sadu.queries.call.adapter.StandardAdapter.*;
+import static de.chojo.sadu.queries.call.adapter.StandardAdapter.INSTANT_AS_MILLIS;
+
+public class InstantTest {
+    private QueryConfiguration query;
+    private PostgresDatabase.Database db;
+
+    @BeforeEach
+    void before() throws IOException, SQLException {
+        db = createContainer("postgres", "postgres");
+        query = new QueryConfigurationBuilder(db.dataSource()).setRowMapperRegistry(new RowMapperRegistry().register(PostgresqlMapper.getDefaultMapper())
+                .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
+    }
+
+    @Test
+    public void asSeconds() {
+        Instant now = Instant.now();
+        query.query("INSERT INTO instant_test(as_epoch_seconds) VALUES (?)")
+                .single(Call.of().bind(now, INSTANT_AS_SECONDS))
+                .insert();
+
+        var res = query.query("SELECT as_epoch_seconds FROM instant_test")
+                .single()
+                .map(row -> row.get(1, INSTANT_FROM_SECONDS))
+                .first()
+                .get();
+        Assertions.assertEquals(now.getEpochSecond(), res.getEpochSecond());
+    }
+
+    @Test
+    public void asMillis() {
+        Instant now = Instant.now();
+        query.query("INSERT INTO instant_test(as_epoch_millis) VALUES (?)")
+                .single(Call.of().bind(now, INSTANT_AS_MILLIS))
+                .insert();
+
+        var res = query.query("SELECT as_epoch_millis FROM instant_test")
+                .single()
+                .map(row -> row.get(1, INSTANT_FROM_MILLIS))
+                .first()
+                .get();
+        Assertions.assertEquals(now.toEpochMilli(), res.toEpochMilli());
+    }
+
+    @Test
+    public void asTimestamp() {
+        Instant now = Instant.now();
+        query.query("INSERT INTO instant_test(as_timestamp) VALUES (?)")
+                .single(Call.of().bind(now, INSTANT_AS_TIMESTAMP))
+                .insert();
+
+        var res = query.query("SELECT as_timestamp FROM instant_test")
+                .single()
+                .map(row -> row.get(1, INSTANT_FROM_TIMESTAMP))
+                .first()
+                .get();
+        Assertions.assertEquals(now.toEpochMilli(), res.toEpochMilli());
+    }
+
+
+}

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/examples/dao/User.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/examples/dao/User.java
@@ -10,8 +10,10 @@ import de.chojo.sadu.mapper.rowmapper.RowMapping;
 
 import java.util.UUID;
 
+import static de.chojo.sadu.mapper.reader.StandardReader.UUID_FROM_STRING;
+
 public record User(int id, UUID uuid, String name) {
     public static RowMapping<User> map() {
-        return row -> new User(row.getInt("id"), row.getUuidFromString("uuid"), row.getString("name"));
+        return row -> new User(row.getInt("id"), row.get("uuid", UUID_FROM_STRING), row.getString("name"));
     }
 }

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/InstantTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/InstantTest.java
@@ -35,25 +35,18 @@ public class InstantTest {
     private QueryConfiguration query;
     private PostgresDatabase.Database db;
 
-    @BeforeEach
-    void before() throws IOException, SQLException {
-        db = createContainer("postgres", "postgres");
-        query = new QueryConfigurationBuilder(db.dataSource()).setRowMapperRegistry(new RowMapperRegistry().register(PostgresqlMapper.getDefaultMapper())
-                .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
-    }
-
     @Test
     public void asSeconds() {
         Instant now = Instant.now();
         query.query("INSERT INTO time_test(as_epoch_seconds) VALUES (?)")
-                .single(Call.of().bind(now, INSTANT_AS_SECONDS))
-                .insert();
+             .single(Call.of().bind(now, INSTANT_AS_SECONDS))
+             .insert();
 
         var res = query.query("SELECT as_epoch_seconds FROM time_test")
-                .single()
-                .map(row -> row.get(1, INSTANT_FROM_SECONDS))
-                .first()
-                .get();
+                       .single()
+                       .map(row -> row.get(1, INSTANT_FROM_SECONDS))
+                       .first()
+                       .get();
         Assertions.assertEquals(now.getEpochSecond(), res.getEpochSecond());
     }
 
@@ -61,14 +54,14 @@ public class InstantTest {
     public void asMillis() {
         Instant now = Instant.now();
         query.query("INSERT INTO time_test(as_epoch_millis) VALUES (?)")
-                .single(Call.of().bind(now, INSTANT_AS_MILLIS))
-                .insert();
+             .single(Call.of().bind(now, INSTANT_AS_MILLIS))
+             .insert();
 
         var res = query.query("SELECT as_epoch_millis FROM time_test")
-                .single()
-                .map(row -> row.get(1, INSTANT_FROM_MILLIS))
-                .first()
-                .get();
+                       .single()
+                       .map(row -> row.get(1, INSTANT_FROM_MILLIS))
+                       .first()
+                       .get();
         Assertions.assertEquals(now.toEpochMilli(), res.toEpochMilli());
     }
 
@@ -76,15 +69,22 @@ public class InstantTest {
     public void asTimestamp() {
         Instant now = Instant.now();
         query.query("INSERT INTO time_test(as_timestamp) VALUES (?)")
-                .single(Call.of().bind(now, INSTANT_AS_TIMESTAMP))
-                .insert();
+             .single(Call.of().bind(now, INSTANT_AS_TIMESTAMP))
+             .insert();
 
         var res = query.query("SELECT as_timestamp FROM time_test")
-                .single()
-                .map(row -> row.get(1, INSTANT_FROM_TIMESTAMP))
-                .first()
-                .get();
+                       .single()
+                       .map(row -> row.get(1, INSTANT_FROM_TIMESTAMP))
+                       .first()
+                       .get();
         Assertions.assertEquals(now.toEpochMilli(), res.toEpochMilli());
+    }
+
+    @BeforeEach
+    void before() throws IOException, SQLException {
+        db = createContainer("postgres", "postgres");
+        query = new QueryConfigurationBuilder(db.dataSource()).setRowMapperRegistry(new RowMapperRegistry().register(PostgresqlMapper.getDefaultMapper())
+                                                                                                           .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
     }
 
     @AfterEach

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/InstantTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/InstantTest.java
@@ -4,7 +4,7 @@
  *     Copyright (C) RainbowDashLabs and Contributor
  */
 
-package de.chojo.sadu.queries;
+package de.chojo.sadu.queries.timeconversion;
 
 import de.chojo.sadu.PostgresDatabase;
 import de.chojo.sadu.mapper.RowMapperRegistry;
@@ -14,9 +14,10 @@ import de.chojo.sadu.queries.api.call.Call;
 import de.chojo.sadu.queries.configuration.QueryConfiguration;
 import de.chojo.sadu.queries.configuration.QueryConfigurationBuilder;
 import de.chojo.sadu.queries.examples.dao.User;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -26,8 +27,9 @@ import static de.chojo.sadu.PostgresDatabase.createContainer;
 import static de.chojo.sadu.mapper.reader.StandardReader.INSTANT_FROM_MILLIS;
 import static de.chojo.sadu.mapper.reader.StandardReader.INSTANT_FROM_SECONDS;
 import static de.chojo.sadu.mapper.reader.StandardReader.INSTANT_FROM_TIMESTAMP;
-import static de.chojo.sadu.queries.call.adapter.StandardAdapter.*;
 import static de.chojo.sadu.queries.call.adapter.StandardAdapter.INSTANT_AS_MILLIS;
+import static de.chojo.sadu.queries.call.adapter.StandardAdapter.INSTANT_AS_SECONDS;
+import static de.chojo.sadu.queries.call.adapter.StandardAdapter.INSTANT_AS_TIMESTAMP;
 
 public class InstantTest {
     private QueryConfiguration query;
@@ -43,11 +45,11 @@ public class InstantTest {
     @Test
     public void asSeconds() {
         Instant now = Instant.now();
-        query.query("INSERT INTO instant_test(as_epoch_seconds) VALUES (?)")
+        query.query("INSERT INTO time_test(as_epoch_seconds) VALUES (?)")
                 .single(Call.of().bind(now, INSTANT_AS_SECONDS))
                 .insert();
 
-        var res = query.query("SELECT as_epoch_seconds FROM instant_test")
+        var res = query.query("SELECT as_epoch_seconds FROM time_test")
                 .single()
                 .map(row -> row.get(1, INSTANT_FROM_SECONDS))
                 .first()
@@ -58,11 +60,11 @@ public class InstantTest {
     @Test
     public void asMillis() {
         Instant now = Instant.now();
-        query.query("INSERT INTO instant_test(as_epoch_millis) VALUES (?)")
+        query.query("INSERT INTO time_test(as_epoch_millis) VALUES (?)")
                 .single(Call.of().bind(now, INSTANT_AS_MILLIS))
                 .insert();
 
-        var res = query.query("SELECT as_epoch_millis FROM instant_test")
+        var res = query.query("SELECT as_epoch_millis FROM time_test")
                 .single()
                 .map(row -> row.get(1, INSTANT_FROM_MILLIS))
                 .first()
@@ -73,11 +75,11 @@ public class InstantTest {
     @Test
     public void asTimestamp() {
         Instant now = Instant.now();
-        query.query("INSERT INTO instant_test(as_timestamp) VALUES (?)")
+        query.query("INSERT INTO time_test(as_timestamp) VALUES (?)")
                 .single(Call.of().bind(now, INSTANT_AS_TIMESTAMP))
                 .insert();
 
-        var res = query.query("SELECT as_timestamp FROM instant_test")
+        var res = query.query("SELECT as_timestamp FROM time_test")
                 .single()
                 .map(row -> row.get(1, INSTANT_FROM_TIMESTAMP))
                 .first()
@@ -85,5 +87,8 @@ public class InstantTest {
         Assertions.assertEquals(now.toEpochMilli(), res.toEpochMilli());
     }
 
-
+    @AfterEach
+    void afterAll() {
+        db.close();
+    }
 }

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/InstantTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/InstantTest.java
@@ -24,12 +24,9 @@ import java.sql.SQLException;
 import java.time.Instant;
 
 import static de.chojo.sadu.PostgresDatabase.createContainer;
-import static de.chojo.sadu.mapper.reader.StandardReader.INSTANT_FROM_MILLIS;
-import static de.chojo.sadu.mapper.reader.StandardReader.INSTANT_FROM_SECONDS;
-import static de.chojo.sadu.mapper.reader.StandardReader.INSTANT_FROM_TIMESTAMP;
-import static de.chojo.sadu.queries.call.adapter.StandardAdapter.INSTANT_AS_MILLIS;
-import static de.chojo.sadu.queries.call.adapter.StandardAdapter.INSTANT_AS_SECONDS;
-import static de.chojo.sadu.queries.call.adapter.StandardAdapter.INSTANT_AS_TIMESTAMP;
+import static de.chojo.sadu.queries.converter.StandardValueConverter.INSTANT_MILLIS;
+import static de.chojo.sadu.queries.converter.StandardValueConverter.INSTANT_SECONDS;
+import static de.chojo.sadu.queries.converter.StandardValueConverter.INSTANT_TIMESTAMP;
 
 public class InstantTest {
     private QueryConfiguration query;
@@ -39,12 +36,12 @@ public class InstantTest {
     public void asSeconds() {
         Instant now = Instant.now();
         query.query("INSERT INTO time_test(as_epoch_seconds) VALUES (?)")
-             .single(Call.of().bind(now, INSTANT_AS_SECONDS))
+             .single(Call.of().bind(now, INSTANT_SECONDS))
              .insert();
 
         var res = query.query("SELECT as_epoch_seconds FROM time_test")
                        .single()
-                       .map(row -> row.get(1, INSTANT_FROM_SECONDS))
+                       .map(row -> row.get(1, INSTANT_SECONDS))
                        .first()
                        .get();
         Assertions.assertEquals(now.getEpochSecond(), res.getEpochSecond());
@@ -54,12 +51,12 @@ public class InstantTest {
     public void asMillis() {
         Instant now = Instant.now();
         query.query("INSERT INTO time_test(as_epoch_millis) VALUES (?)")
-             .single(Call.of().bind(now, INSTANT_AS_MILLIS))
+             .single(Call.of().bind(now, INSTANT_MILLIS))
              .insert();
 
         var res = query.query("SELECT as_epoch_millis FROM time_test")
                        .single()
-                       .map(row -> row.get(1, INSTANT_FROM_MILLIS))
+                       .map(row -> row.get(1, INSTANT_MILLIS))
                        .first()
                        .get();
         Assertions.assertEquals(now.toEpochMilli(), res.toEpochMilli());
@@ -69,12 +66,12 @@ public class InstantTest {
     public void asTimestamp() {
         Instant now = Instant.now();
         query.query("INSERT INTO time_test(as_timestamp) VALUES (?)")
-             .single(Call.of().bind(now, INSTANT_AS_TIMESTAMP))
+             .single(Call.of().bind(now, INSTANT_TIMESTAMP))
              .insert();
 
         var res = query.query("SELECT as_timestamp FROM time_test")
                        .single()
-                       .map(row -> row.get(1, INSTANT_FROM_TIMESTAMP))
+                       .map(row -> row.get(1, INSTANT_TIMESTAMP))
                        .first()
                        .get();
         Assertions.assertEquals(now.toEpochMilli(), res.toEpochMilli());

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/LocalDateTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/LocalDateTest.java
@@ -11,7 +11,6 @@ import de.chojo.sadu.mapper.RowMapperRegistry;
 import de.chojo.sadu.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.postgresql.mapper.PostgresqlMapper;
 import de.chojo.sadu.queries.api.call.Call;
-import de.chojo.sadu.queries.call.adapter.StandardAdapter;
 import de.chojo.sadu.queries.configuration.QueryConfiguration;
 import de.chojo.sadu.queries.configuration.QueryConfigurationBuilder;
 import de.chojo.sadu.queries.examples.dao.User;
@@ -25,7 +24,7 @@ import java.sql.SQLException;
 import java.time.LocalDateTime;
 
 import static de.chojo.sadu.PostgresDatabase.createContainer;
-import static de.chojo.sadu.mapper.reader.StandardReader.LOCAL_DATE;
+import static de.chojo.sadu.queries.converter.StandardValueConverter.LOCAL_DATE;
 
 public class LocalDateTest {
     private QueryConfiguration query;
@@ -35,7 +34,7 @@ public class LocalDateTest {
     public void withoutTimezone() {
         var now = LocalDateTime.of(2000, 1, 1, 0, 0).toLocalDate();
         query.query("INSERT INTO time_test(as_date) VALUES (?)")
-             .single(Call.of().bind(now, StandardAdapter.LOCAL_DATE))
+             .single(Call.of().bind(now, LOCAL_DATE))
              .insert();
 
         var res = query.query("SELECT as_date FROM time_test")

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/LocalDateTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/LocalDateTest.java
@@ -31,26 +31,26 @@ public class LocalDateTest {
     private QueryConfiguration query;
     private PostgresDatabase.Database db;
 
-    @BeforeEach
-    void before() throws IOException, SQLException {
-        db = createContainer("postgres", "postgres");
-        query = new QueryConfigurationBuilder(db.dataSource()).setRowMapperRegistry(new RowMapperRegistry().register(PostgresqlMapper.getDefaultMapper())
-                .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
-    }
-
     @Test
     public void withoutTimezone() {
         var now = LocalDateTime.of(2000, 1, 1, 0, 0).toLocalDate();
         query.query("INSERT INTO time_test(as_date) VALUES (?)")
-                .single(Call.of().bind(now, StandardAdapter.LOCAL_DATE))
-                .insert();
+             .single(Call.of().bind(now, StandardAdapter.LOCAL_DATE))
+             .insert();
 
         var res = query.query("SELECT as_date FROM time_test")
-                .single()
-                .map(row -> row.get(1, LOCAL_DATE))
-                .first()
-                .get();
+                       .single()
+                       .map(row -> row.get(1, LOCAL_DATE))
+                       .first()
+                       .get();
         Assertions.assertEquals(now, res);
+    }
+
+    @BeforeEach
+    void before() throws IOException, SQLException {
+        db = createContainer("postgres", "postgres");
+        query = new QueryConfigurationBuilder(db.dataSource()).setRowMapperRegistry(new RowMapperRegistry().register(PostgresqlMapper.getDefaultMapper())
+                                                                                                           .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
     }
 
     @AfterEach

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/LocalDateTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/LocalDateTest.java
@@ -1,0 +1,60 @@
+/*
+ *     SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *     Copyright (C) RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.queries.timeconversion;
+
+import de.chojo.sadu.PostgresDatabase;
+import de.chojo.sadu.mapper.RowMapperRegistry;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
+import de.chojo.sadu.postgresql.mapper.PostgresqlMapper;
+import de.chojo.sadu.queries.api.call.Call;
+import de.chojo.sadu.queries.call.adapter.StandardAdapter;
+import de.chojo.sadu.queries.configuration.QueryConfiguration;
+import de.chojo.sadu.queries.configuration.QueryConfigurationBuilder;
+import de.chojo.sadu.queries.examples.dao.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+
+import static de.chojo.sadu.PostgresDatabase.createContainer;
+import static de.chojo.sadu.mapper.reader.StandardReader.LOCAL_DATE;
+
+public class LocalDateTest {
+    private QueryConfiguration query;
+    private PostgresDatabase.Database db;
+
+    @BeforeEach
+    void before() throws IOException, SQLException {
+        db = createContainer("postgres", "postgres");
+        query = new QueryConfigurationBuilder(db.dataSource()).setRowMapperRegistry(new RowMapperRegistry().register(PostgresqlMapper.getDefaultMapper())
+                .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
+    }
+
+    @Test
+    public void withoutTimezone() {
+        var now = LocalDateTime.of(2000, 1, 1, 0, 0).toLocalDate();
+        query.query("INSERT INTO time_test(as_date) VALUES (?)")
+                .single(Call.of().bind(now, StandardAdapter.LOCAL_DATE))
+                .insert();
+
+        var res = query.query("SELECT as_date FROM time_test")
+                .single()
+                .map(row -> row.get(1, LOCAL_DATE))
+                .first()
+                .get();
+        Assertions.assertEquals(now, res);
+    }
+
+    @AfterEach
+    void afterAll() {
+        db.close();
+    }
+}

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/LocalDateTimeTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/LocalDateTimeTest.java
@@ -1,0 +1,76 @@
+/*
+ *     SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *     Copyright (C) RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.queries.timeconversion;
+
+import de.chojo.sadu.PostgresDatabase;
+import de.chojo.sadu.mapper.RowMapperRegistry;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
+import de.chojo.sadu.postgresql.mapper.PostgresqlMapper;
+import de.chojo.sadu.queries.api.call.Call;
+import de.chojo.sadu.queries.call.adapter.StandardAdapter;
+import de.chojo.sadu.queries.configuration.QueryConfiguration;
+import de.chojo.sadu.queries.configuration.QueryConfigurationBuilder;
+import de.chojo.sadu.queries.examples.dao.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static de.chojo.sadu.PostgresDatabase.createContainer;
+import static de.chojo.sadu.mapper.reader.StandardReader.LOCAL_DATE_TIME;
+
+public class LocalDateTimeTest {
+    private QueryConfiguration query;
+    private PostgresDatabase.Database db;
+
+    @BeforeEach
+    void before() throws IOException, SQLException {
+        db = createContainer("postgres", "postgres");
+        query = new QueryConfigurationBuilder(db.dataSource()).setRowMapperRegistry(new RowMapperRegistry().register(PostgresqlMapper.getDefaultMapper())
+                .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
+    }
+
+    @Test
+    public void withoutTimezone() {
+        var now = LocalDateTime.now();
+        query.query("INSERT INTO time_test(as_timestamp) VALUES (?)")
+                .single(Call.of().bind(now, StandardAdapter.LOCAL_DATE_TIME))
+                .insert();
+
+        var res = query.query("SELECT as_timestamp FROM time_test")
+                .single()
+                .map(row -> row.get(1, LOCAL_DATE_TIME))
+                .first()
+                .get();
+        Assertions.assertEquals(now.truncatedTo(ChronoUnit.SECONDS), res.truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    @Test
+    public void withTimezone() {
+        var now = LocalDateTime.now();
+        query.query("INSERT INTO time_test(as_timestamp_tz) VALUES (?)")
+                .single(Call.of().bind(now, StandardAdapter.LOCAL_DATE_TIME))
+                .insert();
+
+        var res = query.query("SELECT as_timestamp_tz FROM time_test")
+                .single()
+                .map(row -> row.get(1, LOCAL_DATE_TIME))
+                .first()
+                .get();
+        Assertions.assertEquals(now.truncatedTo(ChronoUnit.SECONDS), res.truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    @AfterEach
+    void afterAll() {
+        db.close();
+    }
+}

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/LocalDateTimeTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/LocalDateTimeTest.java
@@ -11,9 +11,9 @@ import de.chojo.sadu.mapper.RowMapperRegistry;
 import de.chojo.sadu.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.postgresql.mapper.PostgresqlMapper;
 import de.chojo.sadu.queries.api.call.Call;
-import de.chojo.sadu.queries.call.adapter.StandardAdapter;
 import de.chojo.sadu.queries.configuration.QueryConfiguration;
 import de.chojo.sadu.queries.configuration.QueryConfigurationBuilder;
+import de.chojo.sadu.queries.converter.StandardValueConverter;
 import de.chojo.sadu.queries.examples.dao.User;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -26,7 +26,7 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
 import static de.chojo.sadu.PostgresDatabase.createContainer;
-import static de.chojo.sadu.mapper.reader.StandardReader.LOCAL_DATE_TIME;
+import static de.chojo.sadu.queries.converter.StandardValueConverter.LOCAL_DATE_TIME;
 
 public class LocalDateTimeTest {
     private QueryConfiguration query;
@@ -36,7 +36,7 @@ public class LocalDateTimeTest {
     public void withoutTimezone() {
         var now = LocalDateTime.now();
         query.query("INSERT INTO time_test(as_timestamp) VALUES (?)")
-             .single(Call.of().bind(now, StandardAdapter.LOCAL_DATE_TIME))
+             .single(Call.of().bind(now, LOCAL_DATE_TIME))
              .insert();
 
         var res = query.query("SELECT as_timestamp FROM time_test")
@@ -51,7 +51,7 @@ public class LocalDateTimeTest {
     public void withTimezone() {
         var now = LocalDateTime.now();
         query.query("INSERT INTO time_test(as_timestamp_tz) VALUES (?)")
-             .single(Call.of().bind(now, StandardAdapter.LOCAL_DATE_TIME))
+             .single(Call.of().bind(now, LOCAL_DATE_TIME))
              .insert();
 
         var res = query.query("SELECT as_timestamp_tz FROM time_test")

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/LocalDateTimeTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/LocalDateTimeTest.java
@@ -8,7 +8,6 @@ package de.chojo.sadu.queries.timeconversion;
 
 import de.chojo.sadu.PostgresDatabase;
 import de.chojo.sadu.mapper.RowMapperRegistry;
-import de.chojo.sadu.mapper.reader.StandardReader;
 import de.chojo.sadu.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.postgresql.mapper.PostgresqlMapper;
 import de.chojo.sadu.queries.api.call.Call;
@@ -25,36 +24,26 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.Optional;
-import java.util.UUID;
 
 import static de.chojo.sadu.PostgresDatabase.createContainer;
 import static de.chojo.sadu.mapper.reader.StandardReader.LOCAL_DATE_TIME;
-import static de.chojo.sadu.mapper.reader.StandardReader.UUID_FROM_BYTES;
 
 public class LocalDateTimeTest {
     private QueryConfiguration query;
     private PostgresDatabase.Database db;
 
-    @BeforeEach
-    void before() throws IOException, SQLException {
-        db = createContainer("postgres", "postgres");
-        query = new QueryConfigurationBuilder(db.dataSource()).setRowMapperRegistry(new RowMapperRegistry().register(PostgresqlMapper.getDefaultMapper())
-                .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
-    }
-
     @Test
     public void withoutTimezone() {
         var now = LocalDateTime.now();
         query.query("INSERT INTO time_test(as_timestamp) VALUES (?)")
-                .single(Call.of().bind(now, StandardAdapter.LOCAL_DATE_TIME))
-                .insert();
+             .single(Call.of().bind(now, StandardAdapter.LOCAL_DATE_TIME))
+             .insert();
 
         var res = query.query("SELECT as_timestamp FROM time_test")
-                .single()
-                .map(row -> row.get(1, LOCAL_DATE_TIME))
-                .first()
-                .get();
+                       .single()
+                       .map(row -> row.get(1, LOCAL_DATE_TIME))
+                       .first()
+                       .get();
         Assertions.assertEquals(now.truncatedTo(ChronoUnit.SECONDS), res.truncatedTo(ChronoUnit.SECONDS));
     }
 
@@ -62,34 +51,22 @@ public class LocalDateTimeTest {
     public void withTimezone() {
         var now = LocalDateTime.now();
         query.query("INSERT INTO time_test(as_timestamp_tz) VALUES (?)")
-                .single(Call.of().bind(now, StandardAdapter.LOCAL_DATE_TIME))
-                .insert();
+             .single(Call.of().bind(now, StandardAdapter.LOCAL_DATE_TIME))
+             .insert();
 
         var res = query.query("SELECT as_timestamp_tz FROM time_test")
-                .single()
-                .map(row -> row.get(1, LOCAL_DATE_TIME))
-                .first()
-                .get();
+                       .single()
+                       .map(row -> row.get(1, LOCAL_DATE_TIME))
+                       .first()
+                       .get();
         Assertions.assertEquals(now.truncatedTo(ChronoUnit.SECONDS), res.truncatedTo(ChronoUnit.SECONDS));
     }
 
-    public void test(){
-        Optional<UUID> first = query.query("SELECT uuid FROM users")
-                                    .single()
-                                    .map(row -> row.get("uuid", UUID_FROM_BYTES))
-                                    .first();
-
-        Optional<UUID> first = query.query("SELECT uuid FROM users")
-                                    .single()
-                                    .map(row -> row.getUuidFromBytes("uuid"))
-                                    .first();
-
-        Optional<Status> first = query.query("SELECT status FROM users")
-                                    .single()
-                                    .map(row -> row.get("status", StandardReader.forEnum(Status.class)))
-                                    .first();
-
-
+    @BeforeEach
+    void before() throws IOException, SQLException {
+        db = createContainer("postgres", "postgres");
+        query = new QueryConfigurationBuilder(db.dataSource()).setRowMapperRegistry(new RowMapperRegistry().register(PostgresqlMapper.getDefaultMapper())
+                                                                                                           .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
     }
 
     @AfterEach

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/LocalDateTimeTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/LocalDateTimeTest.java
@@ -8,6 +8,7 @@ package de.chojo.sadu.queries.timeconversion;
 
 import de.chojo.sadu.PostgresDatabase;
 import de.chojo.sadu.mapper.RowMapperRegistry;
+import de.chojo.sadu.mapper.reader.StandardReader;
 import de.chojo.sadu.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.postgresql.mapper.PostgresqlMapper;
 import de.chojo.sadu.queries.api.call.Call;
@@ -24,9 +25,12 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import java.util.UUID;
 
 import static de.chojo.sadu.PostgresDatabase.createContainer;
 import static de.chojo.sadu.mapper.reader.StandardReader.LOCAL_DATE_TIME;
+import static de.chojo.sadu.mapper.reader.StandardReader.UUID_FROM_BYTES;
 
 public class LocalDateTimeTest {
     private QueryConfiguration query;
@@ -67,6 +71,25 @@ public class LocalDateTimeTest {
                 .first()
                 .get();
         Assertions.assertEquals(now.truncatedTo(ChronoUnit.SECONDS), res.truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    public void test(){
+        Optional<UUID> first = query.query("SELECT uuid FROM users")
+                                    .single()
+                                    .map(row -> row.get("uuid", UUID_FROM_BYTES))
+                                    .first();
+
+        Optional<UUID> first = query.query("SELECT uuid FROM users")
+                                    .single()
+                                    .map(row -> row.getUuidFromBytes("uuid"))
+                                    .first();
+
+        Optional<Status> first = query.query("SELECT status FROM users")
+                                    .single()
+                                    .map(row -> row.get("status", StandardReader.forEnum(Status.class)))
+                                    .first();
+
+
     }
 
     @AfterEach

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/LocalTimeTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/LocalTimeTest.java
@@ -22,37 +22,35 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 import static de.chojo.sadu.PostgresDatabase.createContainer;
-import static de.chojo.sadu.mapper.reader.StandardReader.LOCAL_DATE;
 import static de.chojo.sadu.mapper.reader.StandardReader.LOCAL_TIME;
 
 public class LocalTimeTest {
     private QueryConfiguration query;
     private PostgresDatabase.Database db;
 
+    @Test
+    public void withoutTimezone() {
+        var now = LocalTime.of(0, 0);
+        query.query("INSERT INTO time_test(as_time) VALUES (?)")
+             .single(Call.of().bind(now, StandardAdapter.LOCAL_TIME))
+             .insert();
+
+        var res = query.query("SELECT as_time FROM time_test")
+                       .single()
+                       .map(row -> row.get(1, LOCAL_TIME))
+                       .first()
+                       .get();
+        Assertions.assertEquals(now, res);
+    }
+
     @BeforeEach
     void before() throws IOException, SQLException {
         db = createContainer("postgres", "postgres");
         query = new QueryConfigurationBuilder(db.dataSource()).setRowMapperRegistry(new RowMapperRegistry().register(PostgresqlMapper.getDefaultMapper())
-                .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
-    }
-
-    @Test
-    public void withoutTimezone() {
-        var now = LocalTime.of( 0, 0);
-        query.query("INSERT INTO time_test(as_time) VALUES (?)")
-                .single(Call.of().bind(now, StandardAdapter.LOCAL_TIME))
-                .insert();
-
-        var res = query.query("SELECT as_time FROM time_test")
-                .single()
-                .map(row -> row.get(1, LOCAL_TIME))
-                .first()
-                .get();
-        Assertions.assertEquals(now, res);
+                                                                                                           .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
     }
 
     @AfterEach

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/LocalTimeTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/LocalTimeTest.java
@@ -1,0 +1,62 @@
+/*
+ *     SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *     Copyright (C) RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.queries.timeconversion;
+
+import de.chojo.sadu.PostgresDatabase;
+import de.chojo.sadu.mapper.RowMapperRegistry;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
+import de.chojo.sadu.postgresql.mapper.PostgresqlMapper;
+import de.chojo.sadu.queries.api.call.Call;
+import de.chojo.sadu.queries.call.adapter.StandardAdapter;
+import de.chojo.sadu.queries.configuration.QueryConfiguration;
+import de.chojo.sadu.queries.configuration.QueryConfigurationBuilder;
+import de.chojo.sadu.queries.examples.dao.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static de.chojo.sadu.PostgresDatabase.createContainer;
+import static de.chojo.sadu.mapper.reader.StandardReader.LOCAL_DATE;
+import static de.chojo.sadu.mapper.reader.StandardReader.LOCAL_TIME;
+
+public class LocalTimeTest {
+    private QueryConfiguration query;
+    private PostgresDatabase.Database db;
+
+    @BeforeEach
+    void before() throws IOException, SQLException {
+        db = createContainer("postgres", "postgres");
+        query = new QueryConfigurationBuilder(db.dataSource()).setRowMapperRegistry(new RowMapperRegistry().register(PostgresqlMapper.getDefaultMapper())
+                .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
+    }
+
+    @Test
+    public void withoutTimezone() {
+        var now = LocalTime.of( 0, 0);
+        query.query("INSERT INTO time_test(as_time) VALUES (?)")
+                .single(Call.of().bind(now, StandardAdapter.LOCAL_TIME))
+                .insert();
+
+        var res = query.query("SELECT as_time FROM time_test")
+                .single()
+                .map(row -> row.get(1, LOCAL_TIME))
+                .first()
+                .get();
+        Assertions.assertEquals(now, res);
+    }
+
+    @AfterEach
+    void afterAll() {
+        db.close();
+    }
+}

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/LocalTimeTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/LocalTimeTest.java
@@ -11,7 +11,6 @@ import de.chojo.sadu.mapper.RowMapperRegistry;
 import de.chojo.sadu.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.postgresql.mapper.PostgresqlMapper;
 import de.chojo.sadu.queries.api.call.Call;
-import de.chojo.sadu.queries.call.adapter.StandardAdapter;
 import de.chojo.sadu.queries.configuration.QueryConfiguration;
 import de.chojo.sadu.queries.configuration.QueryConfigurationBuilder;
 import de.chojo.sadu.queries.examples.dao.User;
@@ -25,7 +24,7 @@ import java.sql.SQLException;
 import java.time.LocalTime;
 
 import static de.chojo.sadu.PostgresDatabase.createContainer;
-import static de.chojo.sadu.mapper.reader.StandardReader.LOCAL_TIME;
+import static de.chojo.sadu.queries.converter.StandardValueConverter.LOCAL_TIME;
 
 public class LocalTimeTest {
     private QueryConfiguration query;
@@ -35,7 +34,7 @@ public class LocalTimeTest {
     public void withoutTimezone() {
         var now = LocalTime.of(0, 0);
         query.query("INSERT INTO time_test(as_time) VALUES (?)")
-             .single(Call.of().bind(now, StandardAdapter.LOCAL_TIME))
+             .single(Call.of().bind(now, LOCAL_TIME))
              .insert();
 
         var res = query.query("SELECT as_time FROM time_test")

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/OffsetDateTimeTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/OffsetDateTimeTest.java
@@ -1,0 +1,76 @@
+/*
+ *     SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *     Copyright (C) RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.queries.timeconversion;
+
+import de.chojo.sadu.PostgresDatabase;
+import de.chojo.sadu.mapper.RowMapperRegistry;
+import de.chojo.sadu.mapper.reader.StandardReader;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
+import de.chojo.sadu.postgresql.mapper.PostgresqlMapper;
+import de.chojo.sadu.queries.api.call.Call;
+import de.chojo.sadu.queries.call.adapter.StandardAdapter;
+import de.chojo.sadu.queries.configuration.QueryConfiguration;
+import de.chojo.sadu.queries.configuration.QueryConfigurationBuilder;
+import de.chojo.sadu.queries.examples.dao.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static de.chojo.sadu.PostgresDatabase.createContainer;
+
+public class OffsetDateTimeTest {
+    private QueryConfiguration query;
+    private PostgresDatabase.Database db;
+
+    @BeforeEach
+    void before() throws IOException, SQLException {
+        db = createContainer("postgres", "postgres");
+        query = new QueryConfigurationBuilder(db.dataSource()).setRowMapperRegistry(new RowMapperRegistry().register(PostgresqlMapper.getDefaultMapper())
+                                                                                                           .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
+    }
+
+    @Test
+    public void withoutTimezone() {
+        var now = OffsetDateTime.now();
+        query.query("INSERT INTO time_test(as_timestamp) VALUES (?)")
+             .single(Call.of().bind(now, StandardAdapter.OFFSET_DATE_TIME))
+             .insert();
+
+        var res = query.query("SELECT as_timestamp FROM time_test")
+                       .single()
+                       .map(row -> row.get(1, StandardReader.OFFSET_DATE_TIME))
+                       .first()
+                       .get();
+        Assertions.assertEquals(now.truncatedTo(ChronoUnit.SECONDS), res.truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    @Test
+    public void withTimezone() {
+        var now = OffsetDateTime.now();
+        query.query("INSERT INTO time_test(as_timestamp_tz) VALUES (?)")
+             .single(Call.of().bind(now, StandardAdapter.OFFSET_DATE_TIME))
+             .insert();
+
+        var res = query.query("SELECT as_timestamp_tz FROM time_test")
+                       .single()
+                       .map(row -> row.get(1, StandardReader.OFFSET_DATE_TIME))
+                       .first()
+                       .get();
+        Assertions.assertEquals(now.truncatedTo(ChronoUnit.SECONDS), res.truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    @AfterEach
+    void afterAll() {
+        db.close();
+    }
+}

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/OffsetDateTimeTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/OffsetDateTimeTest.java
@@ -8,7 +8,6 @@ package de.chojo.sadu.queries.timeconversion;
 
 import de.chojo.sadu.PostgresDatabase;
 import de.chojo.sadu.mapper.RowMapperRegistry;
-import de.chojo.sadu.mapper.reader.StandardReader;
 import de.chojo.sadu.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.postgresql.mapper.PostgresqlMapper;
 import de.chojo.sadu.queries.api.call.Call;
@@ -27,6 +26,7 @@ import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 
 import static de.chojo.sadu.PostgresDatabase.createContainer;
+import static de.chojo.sadu.queries.converter.StandardValueConverter.OFFSET_DATE_TIME;
 
 public class OffsetDateTimeTest {
     private QueryConfiguration query;
@@ -41,7 +41,7 @@ public class OffsetDateTimeTest {
 
         var res = query.query("SELECT as_timestamp FROM time_test")
                        .single()
-                       .map(row -> row.get(1, StandardReader.OFFSET_DATE_TIME))
+                       .map(row -> row.get(1, OFFSET_DATE_TIME))
                        .first()
                        .get();
         Assertions.assertEquals(now.truncatedTo(ChronoUnit.SECONDS), res.truncatedTo(ChronoUnit.SECONDS));
@@ -56,7 +56,7 @@ public class OffsetDateTimeTest {
 
         var res = query.query("SELECT as_timestamp_tz FROM time_test")
                        .single()
-                       .map(row -> row.get(1, StandardReader.OFFSET_DATE_TIME))
+                       .map(row -> row.get(1, OFFSET_DATE_TIME))
                        .first()
                        .get();
         Assertions.assertEquals(now.truncatedTo(ChronoUnit.SECONDS), res.truncatedTo(ChronoUnit.SECONDS));

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/OffsetDateTimeTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/OffsetDateTimeTest.java
@@ -32,13 +32,6 @@ public class OffsetDateTimeTest {
     private QueryConfiguration query;
     private PostgresDatabase.Database db;
 
-    @BeforeEach
-    void before() throws IOException, SQLException {
-        db = createContainer("postgres", "postgres");
-        query = new QueryConfigurationBuilder(db.dataSource()).setRowMapperRegistry(new RowMapperRegistry().register(PostgresqlMapper.getDefaultMapper())
-                                                                                                           .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
-    }
-
     @Test
     public void withoutTimezone() {
         var now = OffsetDateTime.now();
@@ -67,6 +60,13 @@ public class OffsetDateTimeTest {
                        .first()
                        .get();
         Assertions.assertEquals(now.truncatedTo(ChronoUnit.SECONDS), res.truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    @BeforeEach
+    void before() throws IOException, SQLException {
+        db = createContainer("postgres", "postgres");
+        query = new QueryConfigurationBuilder(db.dataSource()).setRowMapperRegistry(new RowMapperRegistry().register(PostgresqlMapper.getDefaultMapper())
+                                                                                                           .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
     }
 
     @AfterEach

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/OffsetTimeTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/OffsetTimeTest.java
@@ -8,11 +8,9 @@ package de.chojo.sadu.queries.timeconversion;
 
 import de.chojo.sadu.PostgresDatabase;
 import de.chojo.sadu.mapper.RowMapperRegistry;
-import de.chojo.sadu.mapper.reader.StandardReader;
 import de.chojo.sadu.mapper.rowmapper.RowMapper;
 import de.chojo.sadu.postgresql.mapper.PostgresqlMapper;
 import de.chojo.sadu.queries.api.call.Call;
-import de.chojo.sadu.queries.call.adapter.StandardAdapter;
 import de.chojo.sadu.queries.configuration.QueryConfiguration;
 import de.chojo.sadu.queries.configuration.QueryConfigurationBuilder;
 import de.chojo.sadu.queries.examples.dao.User;
@@ -27,6 +25,7 @@ import java.time.OffsetTime;
 import java.time.temporal.ChronoUnit;
 
 import static de.chojo.sadu.PostgresDatabase.createContainer;
+import static de.chojo.sadu.queries.converter.StandardValueConverter.OFFSET_TIME;
 
 public class OffsetTimeTest {
     private QueryConfiguration query;
@@ -36,12 +35,12 @@ public class OffsetTimeTest {
     public void withoutTimezone() {
         var now = OffsetTime.now();
         query.query("INSERT INTO time_test(as_time) VALUES (?)")
-             .single(Call.of().bind(now, StandardAdapter.OFFSET_TIME))
+             .single(Call.of().bind(now, OFFSET_TIME))
              .insert();
 
         var res = query.query("SELECT as_time FROM time_test")
                        .single()
-                       .map(row -> row.get(1, StandardReader.OFFSET_TIME))
+                       .map(row -> row.get(1, OFFSET_TIME))
                        .first()
                        .get();
         Assertions.assertEquals(now.truncatedTo(ChronoUnit.SECONDS), res.truncatedTo(ChronoUnit.SECONDS));

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/OffsetTimeTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/OffsetTimeTest.java
@@ -32,13 +32,6 @@ public class OffsetTimeTest {
     private QueryConfiguration query;
     private PostgresDatabase.Database db;
 
-    @BeforeEach
-    void before() throws IOException, SQLException {
-        db = createContainer("postgres", "postgres");
-        query = new QueryConfigurationBuilder(db.dataSource()).setRowMapperRegistry(new RowMapperRegistry().register(PostgresqlMapper.getDefaultMapper())
-                                                                                                           .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
-    }
-
     @Test
     public void withoutTimezone() {
         var now = OffsetTime.now();
@@ -52,6 +45,13 @@ public class OffsetTimeTest {
                        .first()
                        .get();
         Assertions.assertEquals(now.truncatedTo(ChronoUnit.SECONDS), res.truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    @BeforeEach
+    void before() throws IOException, SQLException {
+        db = createContainer("postgres", "postgres");
+        query = new QueryConfigurationBuilder(db.dataSource()).setRowMapperRegistry(new RowMapperRegistry().register(PostgresqlMapper.getDefaultMapper())
+                                                                                                           .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
     }
 
     @AfterEach

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/OffsetTimeTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/OffsetTimeTest.java
@@ -1,0 +1,61 @@
+/*
+ *     SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *     Copyright (C) RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.queries.timeconversion;
+
+import de.chojo.sadu.PostgresDatabase;
+import de.chojo.sadu.mapper.RowMapperRegistry;
+import de.chojo.sadu.mapper.reader.StandardReader;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
+import de.chojo.sadu.postgresql.mapper.PostgresqlMapper;
+import de.chojo.sadu.queries.api.call.Call;
+import de.chojo.sadu.queries.call.adapter.StandardAdapter;
+import de.chojo.sadu.queries.configuration.QueryConfiguration;
+import de.chojo.sadu.queries.configuration.QueryConfigurationBuilder;
+import de.chojo.sadu.queries.examples.dao.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.time.OffsetTime;
+import java.time.temporal.ChronoUnit;
+
+import static de.chojo.sadu.PostgresDatabase.createContainer;
+
+public class OffsetTimeTest {
+    private QueryConfiguration query;
+    private PostgresDatabase.Database db;
+
+    @BeforeEach
+    void before() throws IOException, SQLException {
+        db = createContainer("postgres", "postgres");
+        query = new QueryConfigurationBuilder(db.dataSource()).setRowMapperRegistry(new RowMapperRegistry().register(PostgresqlMapper.getDefaultMapper())
+                                                                                                           .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
+    }
+
+    @Test
+    public void withoutTimezone() {
+        var now = OffsetTime.now();
+        query.query("INSERT INTO time_test(as_time) VALUES (?)")
+             .single(Call.of().bind(now, StandardAdapter.OFFSET_TIME))
+             .insert();
+
+        var res = query.query("SELECT as_time FROM time_test")
+                       .single()
+                       .map(row -> row.get(1, StandardReader.OFFSET_TIME))
+                       .first()
+                       .get();
+        Assertions.assertEquals(now.truncatedTo(ChronoUnit.SECONDS), res.truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    @AfterEach
+    void afterAll() {
+        db.close();
+    }
+}

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/ZonedDateTimeTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/ZonedDateTimeTest.java
@@ -32,25 +32,18 @@ public class ZonedDateTimeTest {
     private QueryConfiguration query;
     private PostgresDatabase.Database db;
 
-    @BeforeEach
-    void before() throws IOException, SQLException {
-        db = createContainer("postgres", "postgres");
-        query = new QueryConfigurationBuilder(db.dataSource()).setRowMapperRegistry(new RowMapperRegistry().register(PostgresqlMapper.getDefaultMapper())
-                .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
-    }
-
     @Test
     public void withoutTimezone() {
         var now = ZonedDateTime.now();
         query.query("INSERT INTO time_test(as_timestamp) VALUES (?)")
-                .single(Call.of().bind(now, StandardAdapter.ZONED_DATE_TIME))
-                .insert();
+             .single(Call.of().bind(now, StandardAdapter.ZONED_DATE_TIME))
+             .insert();
 
         var res = query.query("SELECT as_timestamp FROM time_test")
-                .single()
-                .map(row -> row.get(1, ZONED_DATE_TIME))
-                .first()
-                .get();
+                       .single()
+                       .map(row -> row.get(1, ZONED_DATE_TIME))
+                       .first()
+                       .get();
         Assertions.assertEquals(now.truncatedTo(ChronoUnit.SECONDS), res.truncatedTo(ChronoUnit.SECONDS));
     }
 
@@ -58,15 +51,22 @@ public class ZonedDateTimeTest {
     public void withTimezone() {
         var now = ZonedDateTime.now();
         query.query("INSERT INTO time_test(as_timestamp_tz) VALUES (?)")
-                .single(Call.of().bind(now, StandardAdapter.ZONED_DATE_TIME))
-                .insert();
+             .single(Call.of().bind(now, StandardAdapter.ZONED_DATE_TIME))
+             .insert();
 
         var res = query.query("SELECT as_timestamp_tz FROM time_test")
-                .single()
-                .map(row -> row.get(1, ZONED_DATE_TIME))
-                .first()
-                .get();
+                       .single()
+                       .map(row -> row.get(1, ZONED_DATE_TIME))
+                       .first()
+                       .get();
         Assertions.assertEquals(now.truncatedTo(ChronoUnit.SECONDS), res.truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    @BeforeEach
+    void before() throws IOException, SQLException {
+        db = createContainer("postgres", "postgres");
+        query = new QueryConfigurationBuilder(db.dataSource()).setRowMapperRegistry(new RowMapperRegistry().register(PostgresqlMapper.getDefaultMapper())
+                                                                                                           .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
     }
 
     @AfterEach

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/ZonedDateTimeTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/ZonedDateTimeTest.java
@@ -26,7 +26,7 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 
 import static de.chojo.sadu.PostgresDatabase.createContainer;
-import static de.chojo.sadu.mapper.reader.StandardReader.ZONED_DATE_TIME;
+import static de.chojo.sadu.queries.converter.StandardValueConverter.ZONED_DATE_TIME;
 
 public class ZonedDateTimeTest {
     private QueryConfiguration query;
@@ -36,7 +36,7 @@ public class ZonedDateTimeTest {
     public void withoutTimezone() {
         var now = ZonedDateTime.now();
         query.query("INSERT INTO time_test(as_timestamp) VALUES (?)")
-             .single(Call.of().bind(now, StandardAdapter.ZONED_DATE_TIME))
+             .single(Call.of().bind(now, ZONED_DATE_TIME))
              .insert();
 
         var res = query.query("SELECT as_timestamp FROM time_test")

--- a/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/ZonedDateTimeTest.java
+++ b/sadu-queries/src/test/java/de/chojo/sadu/queries/timeconversion/ZonedDateTimeTest.java
@@ -1,0 +1,76 @@
+/*
+ *     SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *     Copyright (C) RainbowDashLabs and Contributor
+ */
+
+package de.chojo.sadu.queries.timeconversion;
+
+import de.chojo.sadu.PostgresDatabase;
+import de.chojo.sadu.mapper.RowMapperRegistry;
+import de.chojo.sadu.mapper.rowmapper.RowMapper;
+import de.chojo.sadu.postgresql.mapper.PostgresqlMapper;
+import de.chojo.sadu.queries.api.call.Call;
+import de.chojo.sadu.queries.call.adapter.StandardAdapter;
+import de.chojo.sadu.queries.configuration.QueryConfiguration;
+import de.chojo.sadu.queries.configuration.QueryConfigurationBuilder;
+import de.chojo.sadu.queries.examples.dao.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static de.chojo.sadu.PostgresDatabase.createContainer;
+import static de.chojo.sadu.mapper.reader.StandardReader.ZONED_DATE_TIME;
+
+public class ZonedDateTimeTest {
+    private QueryConfiguration query;
+    private PostgresDatabase.Database db;
+
+    @BeforeEach
+    void before() throws IOException, SQLException {
+        db = createContainer("postgres", "postgres");
+        query = new QueryConfigurationBuilder(db.dataSource()).setRowMapperRegistry(new RowMapperRegistry().register(PostgresqlMapper.getDefaultMapper())
+                .register(RowMapper.forClass(User.class).mapper(User.map()).build())).build();
+    }
+
+    @Test
+    public void withoutTimezone() {
+        var now = ZonedDateTime.now();
+        query.query("INSERT INTO time_test(as_timestamp) VALUES (?)")
+                .single(Call.of().bind(now, StandardAdapter.ZONED_DATE_TIME))
+                .insert();
+
+        var res = query.query("SELECT as_timestamp FROM time_test")
+                .single()
+                .map(row -> row.get(1, ZONED_DATE_TIME))
+                .first()
+                .get();
+        Assertions.assertEquals(now.truncatedTo(ChronoUnit.SECONDS), res.truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    @Test
+    public void withTimezone() {
+        var now = ZonedDateTime.now();
+        query.query("INSERT INTO time_test(as_timestamp_tz) VALUES (?)")
+                .single(Call.of().bind(now, StandardAdapter.ZONED_DATE_TIME))
+                .insert();
+
+        var res = query.query("SELECT as_timestamp_tz FROM time_test")
+                .single()
+                .map(row -> row.get(1, ZONED_DATE_TIME))
+                .first()
+                .get();
+        Assertions.assertEquals(now.truncatedTo(ChronoUnit.SECONDS), res.truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    @AfterEach
+    void afterAll() {
+        db.close();
+    }
+}

--- a/sadu-queries/src/test/resources/database/postgresql/1/setup.sql
+++ b/sadu-queries/src/test/resources/database/postgresql/1/setup.sql
@@ -1,23 +1,24 @@
-create table users
-(
-    id   serial
-        constraint users_pk
-            primary key,
-    uuid uuid not null,
-    name text
+CREATE TABLE users (
+    id   SERIAL
+        CONSTRAINT users_pk
+            PRIMARY KEY,
+    uuid UUID NOT NULL,
+    name TEXT
 );
 
-create table birthdays
-(
-    user_id    integer not null
-        constraint birthdays_pk
-            primary key,
-    birth_date date    not null
+CREATE TABLE birthdays (
+    user_id    INTEGER NOT NULL
+        CONSTRAINT birthdays_pk
+            PRIMARY KEY,
+    birth_date DATE    NOT NULL
 );
 
-CREATE TABLE instant_test
-(
+DROP TABLE IF EXISTS time_test;
+CREATE TABLE time_test (
     as_epoch_seconds BIGINT,
     as_epoch_millis  BIGINT,
-    as_timestamp     TIMESTAMP
+    as_timestamp     TIMESTAMP WITHOUT TIME ZONE,
+    as_timestamp_tz  TIMESTAMP WITH TIME ZONE,
+    as_time          TIME,
+    as_date          DATE
 );

--- a/sadu-queries/src/test/resources/database/postgresql/1/setup.sql
+++ b/sadu-queries/src/test/resources/database/postgresql/1/setup.sql
@@ -14,3 +14,10 @@ create table birthdays
             primary key,
     birth_date date    not null
 );
+
+CREATE TABLE instant_test
+(
+    as_epoch_seconds BIGINT,
+    as_epoch_millis  BIGINT,
+    as_timestamp     TIMESTAMP
+);


### PR DESCRIPTION
Implements a ValueReader to convert sql types from a result set into java types. Allowing more complex parsing.
Also deprecates a bunch of additional functions in Row, which are now replaced by a call to Row#get by providing a ValueReader. This allows more modularity on the Row class and allows users to add parsing of their own types without the need to modify the Row class.
It also is closer to the paradigm that Call is using, by providing methods for the base types and offering Adapters for more special types like UUID.

Like the StandardAdapter class a StandardReader class provides basic implementation for the most common datatypes.

Before:
```java
        Optional<UUID> first = query.query("SELECT uuid FROM users")
                                    .single()
                                    .map(row -> row.getUuidFromBytes("uuid"))
                                    .first();
```
Now:
```java
        Optional<UUID> first = query.query("SELECT uuid FROM users")
                                    .single()
                                    .map(row -> row.get("uuid", StandardReader.UUID_FROM_BYTES))
                                    .first();
```

certain special types like enums can be parsed via a factory method
```java
        Optional<Status> first = query.query("SELECT status FROM users")
                                    .single()
                                    .map(row -> row.get("status", StandardReader.forEnum(Status.class)))
                                    .first();
```

For Reading and writing a Value Converter can be used to unify the read and write mechanism. A set of standard implementations is provided via StandardValueConverter. Those also allow to easily use them via static imports to improve readability.

```java
        query.query("INSERT INTO time_test(as_timestamp) VALUES (?)")
             .single(Call.of().bind(now, StandardValueConverter.ZONED_DATE_TIME))
             .insert();

        var res = query.query("SELECT as_timestamp FROM time_test")
                       .single()
                       .map(row -> row.get(1, StandardValueConverter.ZONED_DATE_TIME))
                       .first()
                       .get();
```

Additional use cases:
- Minecraft users could read json from the database and use an adapter to parse it to the required minecraft object already.
- In general serialized objects could already be deserialized inside the adapter, skipping an additional step after reading the result set.
- ...

Resolves #22 