### PR TITLE
Fix JPMS module naming

### DIFF
--- a/sadu-core/src/main/java/module-info.java
+++ b/sadu-core/src/main/java/module-info.java
@@ -1,4 +1,4 @@
-module sadu.sadu.core.main {
+module de.chojo.sadu.core {
     requires transitive java.sql;
     requires transitive org.jetbrains.annotations;
     requires transitive org.slf4j;

--- a/sadu-datasource/src/main/java/module-info.java
+++ b/sadu-datasource/src/main/java/module-info.java
@@ -1,5 +1,5 @@
-module sadu.sadu.datasource.main {
-    requires transitive sadu.sadu.core.main;
+module de.chojo.sadu.datasource {
+    requires transitive de.chojo.sadu.core;
     requires transitive com.zaxxer.hikari;
 
     exports de.chojo.sadu.datasource.stage;

--- a/sadu-mapper/src/main/java/module-info.java
+++ b/sadu-mapper/src/main/java/module-info.java
@@ -1,5 +1,5 @@
-module sadu.sadu.mapper.main {
-    requires transitive sadu.sadu.core.main;
+module de.chojo.sadu.mapper {
+    requires transitive de.chojo.sadu.core;
 
     exports de.chojo.sadu.mapper;
     exports de.chojo.sadu.mapper.reader;

--- a/sadu-mariadb/src/main/java/module-info.java
+++ b/sadu-mariadb/src/main/java/module-info.java
@@ -1,6 +1,6 @@
-module sadu.sadu.mariadb.main {
-    requires transitive sadu.sadu.updater.main;
-    requires transitive sadu.sadu.mapper.main;
+module de.chojo.sadu.mariadb {
+    requires transitive de.chojo.sadu.updater;
+    requires transitive de.chojo.sadu.mapper;
 
     exports de.chojo.sadu.mariadb.databases;
     exports de.chojo.sadu.mariadb.jdbc;

--- a/sadu-mysql/src/main/java/module-info.java
+++ b/sadu-mysql/src/main/java/module-info.java
@@ -1,6 +1,6 @@
-module sadu.sadu.mysql.main {
-    requires transitive sadu.sadu.mapper.main;
-    requires transitive sadu.sadu.updater.main;
+module de.chojo.sadu.mysql {
+    requires transitive de.chojo.sadu.mapper;
+    requires transitive de.chojo.sadu.updater;
 
     exports de.chojo.sadu.mysql.databases;
     exports de.chojo.sadu.mysql.jdbc;

--- a/sadu-postgresql/src/main/java/module-info.java
+++ b/sadu-postgresql/src/main/java/module-info.java
@@ -1,6 +1,6 @@
-module sadu.sadu.postgresql.main {
-    requires transitive sadu.sadu.updater.main;
-    requires transitive sadu.sadu.mapper.main;
+module de.chojo.sadu.postgresql {
+    requires transitive de.chojo.sadu.updater;
+    requires transitive de.chojo.sadu.mapper;
 
     exports de.chojo.sadu.postgresql.databases;
     exports de.chojo.sadu.postgresql.jdbc;

--- a/sadu-queries/src/main/java/module-info.java
+++ b/sadu-queries/src/main/java/module-info.java
@@ -1,6 +1,6 @@
-module sadu.sadu.queries.main {
-    requires transitive sadu.sadu.core.main;
-    requires transitive sadu.sadu.mapper.main;
+module de.chojo.sadu.queries {
+    requires transitive de.chojo.sadu.core;
+    requires transitive de.chojo.sadu.mapper;
 
     exports de.chojo.sadu.queries.api.base;
     exports de.chojo.sadu.queries.api.call;

--- a/sadu-sqlite/src/main/java/module-info.java
+++ b/sadu-sqlite/src/main/java/module-info.java
@@ -1,6 +1,6 @@
-module sadu.sadu.sqlite.main {
-    requires transitive sadu.sadu.updater.main;
-    requires transitive sadu.sadu.mapper.main;
+module de.chojo.sadu.sqlite {
+    requires transitive de.chojo.sadu.updater;
+    requires transitive de.chojo.sadu.mapper;
 
     exports de.chojo.sadu.sqlite.databases;
     exports de.chojo.sadu.sqlite.jdbc;

--- a/sadu-testing/src/main/java/module-info.java
+++ b/sadu-testing/src/main/java/module-info.java
@@ -1,5 +1,5 @@
-module sadu.sadu.testing.main {
-    requires transitive sadu.sadu.core.main;
+module de.chojo.sadu.testing {
+    requires transitive de.chojo.sadu.core;
     requires transitive org.junit.jupiter.api;
 
     exports de.chojo.sadu.testing;

--- a/sadu-updater/src/main/java/module-info.java
+++ b/sadu-updater/src/main/java/module-info.java
@@ -1,5 +1,5 @@
-module sadu.sadu.updater.main {
-    requires transitive sadu.sadu.core.main;
+module de.chojo.sadu.updater {
+    requires transitive de.chojo.sadu.core;
 
     exports de.chojo.sadu.updater;
 }


### PR DESCRIPTION
Previously, JPMS module names didn't follow conventions and were unintuitive.  